### PR TITLE
more error info to CLI output - how to test?

### DIFF
--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -26,15 +26,17 @@ pub struct Lockfile {
 impl Lockfile {
     // Load lock data from a `Cargo.lock` file
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let mut file = File::open(path.as_ref())?;
+        let lockfile_str = path.as_ref().to_str().unwrap();
+        let mut file = File::open(path.as_ref())
+            .expect(format!("could not load lockfile: {:?}", lockfile_str).as_str());
         let mut toml = String::new();
         file.read_to_string(&mut toml)?;
-        Self::from_toml(&toml)
+        Self::from_toml(&lockfile_str, &toml)
     }
 
     // Parse the TOML data from the `Cargo.lock` file
-    pub fn from_toml(toml_string: &str) -> Result<Self, Error> {
-        Ok(toml::from_str(toml_string)?)
+    pub fn from_toml(lockfile: &str, toml_string: &str) -> Result<Self, Error> {
+        Ok(toml::from_str(toml_string).expect(format!("could not parse lockfile: {:?}", lockfile).as_str()))
     }
 }
 
@@ -49,13 +51,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "No such file or directory (os error 2)")]
+    #[should_panic(expected = "could not load lockfile: \"nosuchfile.notexist\"")]
     fn load_cargo_lockfile_nonexistant() {
         Lockfile::load("nosuchfile.notexist").unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "unexpected character found: `<` at line 1")]
+    #[should_panic(expected = "could not parse lockfile: \"README.md\"")]
     fn load_cargo_lockfile_invalid() {
         Lockfile::load("README.md").unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn get_api_key() -> String {
 }
 
 fn audit(lockfile_path: String) -> ! {
-    let lockfile : Lockfile = Lockfile::load(&lockfile_path).unwrap_or_else(|e| {
+    let lockfile : Lockfile = Lockfile::load(lockfile_path).unwrap_or_else(|e| {
         println!("{}", e);
         process::exit(3);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,8 +69,8 @@ fn get_api_key() -> String {
 }
 
 fn audit(lockfile_path: String) -> ! {
-    let lockfile : Lockfile = Lockfile::load(lockfile_path).unwrap_or_else(|e| {
-        println!("{}", e);
+    let lockfile : Lockfile = Lockfile::load(&lockfile_path).unwrap_or_else(|e| {
+        println!("could not load lockfile: {}, error: {}", &lockfile_path, e);
         process::exit(3);
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn get_api_key() -> String {
 
 fn audit(lockfile_path: String) -> ! {
     let lockfile : Lockfile = Lockfile::load(&lockfile_path).unwrap_or_else(|e| {
-        println!("could not load lockfile: {}, error: {}", &lockfile_path, e);
+        println!("{}", e);
         process::exit(3);
     });
 


### PR DESCRIPTION
This PR adds more information about the parameter value that is causing problems, by displaying the parameter value in the error message (e.g. missing cargo lock file).

I wanted to write a little test to verify this change, and started looking into tools like: [assert_cmd](https://docs.rs/assert_cmd/0.11.1/assert_cmd/).

I went pretty far down the rabbit hole trying to basically exec the binary and validate the return code and message printed, but didn’t quite end up where I’d hoped.

Perhaps refactoring “where” such messages are built is a better approach. E.g. move the message building out of main.rs, and into a more easily unit tested location (e.g. Lockfile). Curious to hear what others think.

This pull request makes the following changes:
* show more info about “why” a CLI failure occurs when the cargo lock file is missing.

----

So I went ahead and "moved" the error message formatting out of main, and into Lockfile in fa3e554.
I think this smells better. What do others think?