### PR TITLE
Fix circle ci publish

### DIFF
--- a/.circleci/ci-publish.sh
+++ b/.circleci/ci-publish.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+git config user.name "$GITHUB_USERNAME" && git config user.email "$GITHUB_EMAIL"
+
+cargo install cargo-bump --force
+
+cargo bump patch
+
+VERSION=$(grep -e '^version' Cargo.toml | cut -d "\"" -f2)
+
+git commit -S -am "[skip ci] new development bump to $VERSION"
+
+git tag -a $VERSION -m "$VERSION release"
+
+cargo publish --token --verbose $CARGO_REGISTRY_TOKEN
+
+git push origin --follow-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,8 @@ jobs:
             - "ca:b3:cd:ca:06:0d:42:99:78:27:26:e2:5b:b7:94:a3"
       - checkout
       - run:
-          name: Install cargo-release
-          command: cargo install cargo-release --force
-      - run:
-          name: Setup git
-          command: git config user.name "$GITHUB_USERNAME" && git config user.email "$GITHUB_EMAIL"
-      - run:
           name: Run publish
-          command: cargo release --no-confirm -v --token $CARGO_REGISTRY_TOKEN
+          command: .circleci/ci-publish.sh
 
   build:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.1.15-alpha-0"
+version = "0.1.15"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.1.12"
+version = "0.1.13-alpha-0"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.1.13"
+version = "0.1.14-alpha-0"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.1.14-alpha-0"
+version = "0.1.14"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.1.12-alpha-0"
+version = "0.1.12"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.1.14"
+version = "0.1.15-alpha-0"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.1.11-alpha-0"
+version = "0.1.12-alpha-0"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.1.13-alpha-0"
+version = "0.1.13"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pants"
-version = "0.1.12"
+version = "0.1.13-alpha-0"
 authors = ["Glenn Mohre <glenn.mohre@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pants"
-version = "0.1.14-alpha-0"
+version = "0.1.14"
 authors = ["Glenn Mohre <glenn.mohre@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pants"
-version = "0.1.11-alpha-0"
+version = "0.1.12-alpha-0"
 authors = ["Glenn Mohre <glenn.mohre@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pants"
-version = "0.1.14"
+version = "0.1.15-alpha-0"
 authors = ["Glenn Mohre <glenn.mohre@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pants"
-version = "0.1.13"
+version = "0.1.14-alpha-0"
 authors = ["Glenn Mohre <glenn.mohre@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pants"
-version = "0.1.12-alpha-0"
+version = "0.1.12"
 authors = ["Glenn Mohre <glenn.mohre@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pants"
-version = "0.1.15-alpha-0"
+version = "0.1.15"
 authors = ["Glenn Mohre <glenn.mohre@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pants"
-version = "0.1.13-alpha-0"
+version = "0.1.13"
 authors = ["Glenn Mohre <glenn.mohre@gmail.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
Try doing this by hand since we couldn't get `cargo-release` to work!

This pull request makes the following changes:
* New `ci-publish.sh` file in `.circleci` that does all the publish bits by hand!


It relates to the following issue #s:
* Fixes #18 
