### PR TITLE
#17 Make the output quiet by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ cargo pants
 
 ## Usage
 
-`cargo pants` can be run in your builds context, or ran separately. Two command line flags are supported:
+`cargo pants` can be run in your builds context, or ran separately. Two command line options are supported:
 
 ```
 $ cargo pants --lockfile /path/to/Cargo.lock
@@ -60,7 +60,7 @@ $ cargo pants --lockfile /path/to/Cargo.lock
 
 This allows you to run `cargo pants` on a `Cargo.lock` file anywhere on your filesystem.
 
-If this flag is not supplied, `cargo pants` will assume a local `Cargo.lock` file.
+If this option is not supplied, `cargo pants` will assume a local `Cargo.lock` file.
 
 We will also inform you of our opinions of your pants style choice:
 
@@ -69,6 +69,11 @@ $ cargo pants --pants_style JNCO
 ```
 
 We are very serious about pants.
+
+There is also the option to show all non-vulnerable dependencies for a complete Bill of Materials.
+```
+$ cargo pants --loud --lockfile /path/to/Cargo.lock
+```
 
 If vulnerabilities are found, `cargo-pants` exits with status code 3, and prints the Bill Of Materials/Found Vulnerabilities. If there are no issues, it will exit with status code 0.
 

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct Coordinate {
     #[serde(rename(deserialize = "coordinates"))]
     pub purl: String,
@@ -9,6 +9,12 @@ pub struct Coordinate {
     pub reference: String,
     #[serde(default)]
     pub vulnerabilities: Vec<Vulnerability>,
+}
+
+impl Coordinate {
+    pub fn has_vulnerabilities(&self) -> bool {
+        self.vulnerabilities.len() > 0
+    }
 }
 
 impl fmt::Display for Coordinate {
@@ -21,7 +27,7 @@ impl fmt::Display for Coordinate {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Vulnerability {
     pub title: String,
@@ -59,5 +65,18 @@ mod tests {
             "https://ossindex.sonatype.org/component/pkg:pypi/rust@0.1.1"
         );
         assert_eq!(coordinate.description, "Ribo-Seq Unit Step Transformation");
+    }
+
+    #[test]
+    fn test_has_no_vulnerabilities() {
+        let coordinate = Coordinate::default();
+        assert_eq!(coordinate.has_vulnerabilities(), false);
+    }
+
+    #[test]
+    fn test_has_vulnerabilities() {
+        let mut coordinate = Coordinate::default();
+        coordinate.vulnerabilities.push(Vulnerability::default());
+        assert_eq!(coordinate.has_vulnerabilities(), true);
     }
 }


### PR DESCRIPTION
Changed to follow the requirements within Issue #17

This pull request makes the following changes:
Adds the new --loud option (-v for short, as in verbose, as -l is already in use for --lockfile)
Reformats the output to match that shown in the raised issue.

It relates to the following issue #s:
* Implements #17 
