### PR TITLE
#15 Display vulnerabilities in tabular format and add color

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
- "memchr 2.3.3",
+ "memchr",
 ]
 
 [[package]]
@@ -40,16 +40,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
+name = "ansi_term"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "atty"
@@ -98,27 +95,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "byteorder"
@@ -141,6 +121,7 @@ dependencies = [
 name = "cargo-pants"
 version = "0.1.23"
 dependencies = [
+ "ansi_term 0.12.1",
  "atty",
  "chrono",
  "clap",
@@ -148,17 +129,17 @@ dependencies = [
  "failure",
  "failure_derive",
  "futures",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "mockito",
  "platforms",
- "prettytable-rs",
  "reqwest",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
- "term 0.5.2",
+ "termsize",
+ "textwrap 0.13.4",
  "tokio-core",
  "toml",
  "url 1.7.2",
@@ -193,11 +174,11 @@ version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -218,15 +199,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 dependencies = [
  "atty",
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
@@ -301,7 +276,7 @@ dependencies = [
  "autocfg 1.0.0",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static 1.4.0",
+ "lazy_static",
  "maybe-uninit",
  "memoffset",
  "scopeguard",
@@ -326,18 +301,7 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.0",
  "cfg-if",
- "lazy_static 1.4.0",
-]
-
-[[package]]
-name = "csv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef22b37c7a51c564a365892c012dc0271221fdcc64c69b19ba4d6fa8bd96d9c"
-dependencies = [
- "byteorder",
- "memchr 1.0.2",
- "rustc-serialize",
+ "lazy_static",
 ]
 
 [[package]]
@@ -345,17 +309,6 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "dtoa"
@@ -368,12 +321,6 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -682,21 +629,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "lock_api"
@@ -727,15 +668,6 @@ name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
-name = "memchr"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memchr"
@@ -837,7 +769,7 @@ dependencies = [
  "colored",
  "difference",
  "httparse",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "rand 0.5.6",
  "regex",
@@ -850,7 +782,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -903,6 +835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "object"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,7 +855,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "openssl-sys",
 ]
@@ -961,7 +899,7 @@ dependencies = [
  "cfg-if",
  "cloudabi",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.56",
  "rustc_version",
  "smallvec",
  "winapi 0.3.9",
@@ -998,20 +936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
-name = "prettytable-rs"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34dc1f4f6dddab3bf008ecfd4fd2a631b585fbf0af123f34c1324f51a034ff5f"
-dependencies = [
- "atty",
- "csv",
- "encode_unicode",
- "lazy_static 0.2.11",
- "term 0.4.6",
- "unicode-width",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,7 +952,7 @@ checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
 dependencies = [
  "error-chain",
  "idna 0.2.0",
- "lazy_static 1.4.0",
+ "lazy_static",
  "regex",
  "url 2.1.1",
 ]
@@ -1224,14 +1148,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
-name = "redox_users"
-version = "0.3.4"
+name = "redox_syscall"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
- "getrandom",
- "redox_syscall",
- "rust-argon2",
+ "bitflags",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall 0.2.5",
 ]
 
 [[package]]
@@ -1241,7 +1172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
- "memchr 2.3.3",
+ "memchr",
  "regex-syntax",
  "thread_local",
 ]
@@ -1267,7 +1198,7 @@ version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 dependencies = [
- "base64 0.10.1",
+ "base64",
  "bytes",
  "cookie",
  "cookie_store",
@@ -1296,28 +1227,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
-dependencies = [
- "base64 0.11.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"
@@ -1340,7 +1253,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi 0.3.9",
 ]
 
@@ -1454,6 +1367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,29 +1419,8 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand 0.7.3",
- "redox_syscall",
+ "redox_syscall 0.1.56",
  "remove_dir_all",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "term"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
-dependencies = [
- "kernel32-sys",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "term"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-dependencies = [
- "byteorder",
- "dirs",
  "winapi 0.3.9",
 ]
 
@@ -1536,6 +1434,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall 0.2.5",
+ "redox_termios",
+]
+
+[[package]]
+name = "termsize"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e86d824a8e90f342ad3ef4bd51ef7119a9b681b0cc9f8ee7b2852f02ccd2517"
+dependencies = [
+ "atty",
+ "kernel32-sys",
+ "libc",
+ "termion",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,12 +1468,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
+dependencies = [
+ "smawk",
+ "unicode-width",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -1684,7 +1617,7 @@ checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils",
  "futures",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "mio",
  "num_cpus",
@@ -1729,7 +1662,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "futures",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "num_cpus",
  "slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,24 +9,25 @@ description = "cargo-pants is a cargo subcommand application that provides a bil
 license = "Apache-2.0"
 
 [dependencies]
+ansi_term = "0.12.1"
 atty = "0.2"
-reqwest = "0.9.11"
+chrono = { version = "0.4", optional = true }
 clap = "2.32.0"
 env_logger = "0.6.1"
-chrono = { version = "0.4", optional = true }
-futures = "0.1.25"
-prettytable-rs = "0.6.7"
 failure = "0.1"
 failure_derive = "0.1"
-lazy_static = "1"
+futures = "0.1.25"
+lazy_static = "1.4.0"
 log = "0.4.0"
+mockito = "0.15.1"
 platforms = "0.1"
+reqwest = "0.9.11"
 semver = { version = "0.9", features = ["serde"] }
 serde = "1.0.42"
 serde_derive = "1.0.42"
 serde_json = "1.0.16"
+termsize = "0.1.6"
+textwrap = "0.13.4"
 tokio-core = "0.1.17"
-url = "1.7.0"
-mockito = "0.15.1"
-term = "0.5"
 toml = "0.4"
+url = "1.7.0"

--- a/README.md
+++ b/README.md
@@ -70,10 +70,18 @@ $ cargo pants --pants_style JNCO
 
 We are very serious about pants.
 
-There is also the option to show all non-vulnerable dependencies for a complete Bill of Materials.
+There are also two command line flags that affect the output further:
+
 ```
 $ cargo pants --loud --lockfile /path/to/Cargo.lock
 ```
+This shows all non-vulnerable dependencies for a complete Bill of Materials.
+
+```
+$ cargo pants --no-color --lockfile /path/to/Cargo.lock
+```
+This disables any coloring of the output.
+
 
 If vulnerabilities are found, `cargo-pants` exits with status code 3, and prints the Bill Of Materials/Found Vulnerabilities. If there are no issues, it will exit with status code 0.
 

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use crate::Vulnerability;
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Coordinate {
@@ -15,6 +16,40 @@ impl Coordinate {
     pub fn has_vulnerabilities(&self) -> bool {
         self.vulnerabilities.len() > 0
     }
+
+    pub fn get_threat_score(&self) -> u8 {
+        let mut score = 0u8;
+        for vulnerability in &self.vulnerabilities {
+            score = score.max(vulnerability.cvss_score as u8);
+        }
+        score
+    }
+
+    pub fn get_threat_color(&self) -> Option<ansi_term::Color> {
+        use ansi_term::Color;
+
+        match self.get_threat_score() {
+            9..=10 => Some(Color::Red),
+            7..=8 => Some(Color::Red),
+            4..=6 => Some(Color::Yellow),
+            _ => None,
+        }
+    }
+
+    pub fn get_threat_format(&self) -> ansi_term::Style {
+        use ansi_term::{Color, Style};
+
+        let color: Option<Color> = self.get_threat_color();
+        match color {
+            Some(value) => {
+                match self.get_threat_score() {
+                    9..=10 => value.bold(),
+                    _ => value.normal(),
+                }
+            },
+            None => Style::default()
+        }
+    }
 }
 
 impl fmt::Display for Coordinate {
@@ -27,25 +62,6 @@ impl fmt::Display for Coordinate {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Vulnerability {
-    pub title: String,
-    pub description: String,
-    pub cvss_score: f32,
-    pub cvss_vector: String,
-    pub reference: String,
-}
-
-impl fmt::Display for Vulnerability {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}\n{}\n{}\n{}\n{}",
-            self.title, self.description, self.cvss_score, self.cvss_vector, self.reference
-        )
-    }
-}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use crate::Vulnerability;
+use std::fmt;
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Coordinate {
@@ -41,13 +41,11 @@ impl Coordinate {
 
         let color: Option<Color> = self.get_threat_color();
         match color {
-            Some(value) => {
-                match self.get_threat_score() {
-                    9..=10 => value.bold(),
-                    _ => value.normal(),
-                }
+            Some(value) => match self.get_threat_score() {
+                9..=10 => value.bold(),
+                _ => value.normal(),
             },
-            None => Style::default()
+            None => Style::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,20 @@ extern crate serde_json;
 
 pub mod client;
 pub mod coordinate;
+pub mod vulnerability;
 pub mod error;
 pub mod lockfile;
 pub mod package;
 
-pub use crate::{client::*, coordinate::*, error::*, lockfile::*, package::*};
+pub use crate::{client::*, coordinate::*, vulnerability::*, error::*, lockfile::*, package::*};
+
+// Global Singletons are bad kids. Don't use them (unless you need the terminal width everywhere).
+const DEFAULT_TERM_SIZE:termsize::Size = termsize::Size{cols: 80, rows: 40};
+use lazy_static::lazy_static;
+lazy_static! {
+    pub static ref TERM_WIDTH:u16 = calculate_term_width();
+}
+
+fn calculate_term_width() -> u16 {
+    termsize::get().unwrap_or(DEFAULT_TERM_SIZE).cols
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,18 +24,18 @@ extern crate serde_json;
 
 pub mod client;
 pub mod coordinate;
-pub mod vulnerability;
 pub mod error;
 pub mod lockfile;
 pub mod package;
+pub mod vulnerability;
 
-pub use crate::{client::*, coordinate::*, vulnerability::*, error::*, lockfile::*, package::*};
+pub use crate::{client::*, coordinate::*, error::*, lockfile::*, package::*, vulnerability::*};
 
 // Global Singletons are bad kids. Don't use them (unless you need the terminal width everywhere).
-const DEFAULT_TERM_SIZE:termsize::Size = termsize::Size{cols: 80, rows: 40};
+const DEFAULT_TERM_SIZE: termsize::Size = termsize::Size { cols: 80, rows: 40 };
 use lazy_static::lazy_static;
 lazy_static! {
-    pub static ref TERM_WIDTH:u16 = calculate_term_width();
+    pub static ref TERM_WIDTH: u16 = calculate_term_width();
 }
 
 fn calculate_term_width() -> u16 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ fn write_package_output(
     package_count: u32,
     vulnerable: bool,
     enable_color: bool,
-    width_override: Option<u16>
+    width_override: Option<u16>,
 ) -> io::Result<()> {
     use ansi_term::{Color, Style};
 
@@ -304,7 +304,7 @@ mod tests {
             package_count,
             false,
             false,
-            Some(30)
+            Some(30),
         )
         .unwrap();
         assert_eq!(
@@ -315,9 +315,6 @@ mod tests {
 
     #[test]
     fn write_package_output_vulnerable() {
-
-
-
         let (coordinates, package_count) = setup_test_coordinates();
         let mut package_output = Vec::new();
         write_package_output(

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,7 @@ fn audit(lockfile_path: String, verbose_output: bool, enable_color: bool) -> ! {
             non_vulnerable_package_count,
             false,
             enable_color,
+            None,
         )
         .expect("Error writing non-vulnerable packages to output");
     }
@@ -130,6 +131,7 @@ fn audit(lockfile_path: String, verbose_output: bool, enable_color: bool) -> ! {
             vulnerable_package_count,
             true,
             enable_color,
+            None,
         )
         .expect("Error writing vulnerable packages to output");
     }
@@ -152,6 +154,7 @@ fn write_package_output(
     package_count: u32,
     vulnerable: bool,
     enable_color: bool,
+    width_override: Option<u16>
 ) -> io::Result<()> {
     use ansi_term::{Color, Style};
 
@@ -205,7 +208,7 @@ fn write_package_output(
             for vulnerability in &coordinate.vulnerabilities {
                 if !vulnerability.title.is_empty() {
                     vulnerability
-                        .output_table(output, enable_color)
+                        .output_table(output, enable_color, width_override)
                         .expect("Unable to output Vulnerability details");
                     writeln!(output, "\n")?;
                 }
@@ -301,6 +304,7 @@ mod tests {
             package_count,
             false,
             false,
+            Some(30)
         )
         .unwrap();
         assert_eq!(
@@ -311,6 +315,9 @@ mod tests {
 
     #[test]
     fn write_package_output_vulnerable() {
+
+
+
         let (coordinates, package_count) = setup_test_coordinates();
         let mut package_output = Vec::new();
         write_package_output(
@@ -319,11 +326,47 @@ mod tests {
             package_count,
             true,
             false,
+            Some(30),
         )
         .unwrap();
         assert_eq!(
            convert_output(&package_output),
-           "\nVulnerable Dependencies\n\n[1/3] coord one purl-1vuln\n1 known vulnerability found\n\ncoord1-vuln1 title\n\n0\n\n\n\n[2/3] coord two purl-3vulns\n3 known vulnerabilities found\n\ncoord2-vuln1 title\n\n0\n\n\n\ncoord2-vuln3 title\n\n0\n\n\n\n"
+           "\nVulnerable Dependencies\n\n[1/3] coord one purl-1vuln\n1 known vulnerability found\n\
+           ╭────────────────────────────╮\
+           │ coord1-vuln1 title         │\
+           ├─────────────┬──────────────┤\
+           │ Description ┆              │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │  CVSS Score ┆ 0            │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │ CVSS Vector ┆              │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │   Reference ┆              │\
+           ╰─────────────┴──────────────╯\
+           \n\n[2/3] coord two purl-3vulns\n3 known vulnerabilities found\n\
+           ╭────────────────────────────╮\
+           │ coord2-vuln1 title         │\
+           ├─────────────┬──────────────┤\
+           │ Description ┆              │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │  CVSS Score ┆ 0            │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │ CVSS Vector ┆              │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │   Reference ┆              │\
+           ╰─────────────┴──────────────╯\n\n\
+           ╭────────────────────────────╮\
+           │ coord2-vuln3 title         │\
+           ├─────────────┬──────────────┤\
+           │ Description ┆              │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │  CVSS Score ┆ 0            │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │ CVSS Vector ┆              │\
+           ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤\
+           │   Reference ┆              │\
+           ╰─────────────┴──────────────╯\
+           \n\n"
        );
     }
 

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -21,10 +21,13 @@ impl Vulnerability {
         }
     }
 
-    pub fn output_table(&self, output: &mut dyn Write, enable_color: bool) -> std::io::Result<()> {
+    pub fn output_table(&self, output: &mut dyn Write, enable_color: bool, width_override: Option<u16>) -> std::io::Result<()> {
         use ansi_term::Style;
 
-        let width: u16 = *crate::TERM_WIDTH;
+        let width = match width_override {
+            Some(width) => width,
+            None => *crate::TERM_WIDTH
+        };
 
         self.write_divider(output, "─", "╭", "╮", "─", width)?;
 
@@ -112,8 +115,12 @@ impl Vulnerability {
     ) -> std::io::Result<()> {
         let mut is_first = true;
         let label_wrap_length = 11;
+        let wrap_length = match label {
+            Some(_) => width - 18.min(width),
+            None => width - 4
+        };
         let mut text_wrap_length = width - 18.min(width);
-        let lines = textwrap::wrap(text, text_wrap_length as usize);
+        let lines = textwrap::wrap(text, wrap_length as usize);
         for line in lines {
             write!(output, "│ ")?;
             if let Some(value) = label {

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -21,12 +21,17 @@ impl Vulnerability {
         }
     }
 
-    pub fn output_table(&self, output: &mut dyn Write, enable_color: bool, width_override: Option<u16>) -> std::io::Result<()> {
+    pub fn output_table(
+        &self,
+        output: &mut dyn Write,
+        enable_color: bool,
+        width_override: Option<u16>,
+    ) -> std::io::Result<()> {
         use ansi_term::Style;
 
         let width = match width_override {
             Some(width) => width,
-            None => *crate::TERM_WIDTH
+            None => *crate::TERM_WIDTH,
         };
 
         self.write_divider(output, "─", "╭", "╮", "─", width)?;
@@ -117,7 +122,7 @@ impl Vulnerability {
         let label_wrap_length = 11;
         let wrap_length = match label {
             Some(_) => width - 18.min(width),
-            None => width - 4
+            None => width - 4,
         };
         let mut text_wrap_length = width - 18.min(width);
         let lines = textwrap::wrap(text, wrap_length as usize);

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -1,0 +1,244 @@
+use std::fmt;
+use std::io::Write;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Vulnerability {
+    pub title: String,
+    pub description: String,
+    pub cvss_score: f32,
+    pub cvss_vector: String,
+    pub reference: String,
+}
+
+impl Vulnerability {
+    fn get_title_style(&self) -> ansi_term::Style {
+        match self.cvss_score as u8 {
+            9..=10 => ansi_term::Color::Red.bold(),
+            7..=8 => ansi_term::Color::Red.normal(),
+            4..=6 => ansi_term::Color::Yellow.normal(),
+            _ => ansi_term::Style::default(),
+        }
+    }
+
+    pub fn output_table(&self, output: &mut dyn Write, enable_color: bool) -> std::io::Result<()> {
+        use ansi_term::Style;
+
+        let width: u16 = *crate::TERM_WIDTH;
+
+        self.write_divider(output, "─", "╭", "╮", "─", width)?;
+
+        self.write_section(
+            output,
+            None,
+            &self.title,
+            self.get_title_style(),
+            width,
+            enable_color,
+        )?;
+
+        self.write_divider(output, "─", "├", "┤", "┬", width)?;
+
+        self.write_section(
+            output,
+            Some("Description"),
+            &self.description,
+            Style::default(),
+            width,
+            enable_color,
+        )?;
+        self.write_divider(output, "╌", "├", "┤", "┼", width)?;
+
+        self.write_section(
+            output,
+            Some("CVSS Score"),
+            &self.cvss_score.to_string(),
+            Style::default(),
+            width,
+            enable_color,
+        )?;
+        self.write_divider(output, "╌", "├", "┤", "┼", width)?;
+
+        self.write_section(
+            output,
+            Some("CVSS Vector"),
+            &self.cvss_vector,
+            Style::default(),
+            width,
+            enable_color,
+        )?;
+        self.write_divider(output, "╌", "├", "┤", "┼", width)?;
+
+        self.write_section(
+            output,
+            Some("Reference"),
+            &self.reference,
+            Style::default(),
+            width,
+            enable_color,
+        )?;
+
+        self.write_divider(output, "─", "╰", "╯", "┴", width)?;
+
+        Ok(())
+    }
+
+    pub fn write_divider(
+        &self,
+        output: &mut dyn Write,
+        line: &str,
+        left: &str,
+        right: &str,
+        intersection: &str,
+        width: u16,
+    ) -> std::io::Result<()> {
+        write!(output, "{}", left)?;
+        write!(output, "{}", line.repeat(13))?;
+        write!(output, "{}", intersection)?;
+        write!(output, "{}", line.repeat((width - 16.min(width)) as usize))?;
+        write!(output, "{}", right)?;
+
+        Ok(())
+    }
+
+    pub fn write_section(
+        &self,
+        output: &mut dyn Write,
+        label: Option<&str>,
+        text: &str,
+        text_style: ansi_term::Style,
+        width: u16,
+        enable_color: bool,
+    ) -> std::io::Result<()> {
+        let mut is_first = true;
+        let label_wrap_length = 11;
+        let mut text_wrap_length = width - 18.min(width);
+        let lines = textwrap::wrap(text, text_wrap_length as usize);
+        for line in lines {
+            write!(output, "│ ")?;
+            if let Some(value) = label {
+                if is_first {
+                    is_first = false;
+
+                    if value.len() < label_wrap_length {
+                        for _ in 0..(label_wrap_length - value.len()) {
+                            write!(output, " ")?;
+                        }
+                    }
+                    write!(output, "{}", value)?;
+                } else {
+                    write!(
+                        output,
+                        "{}",
+                        " ".repeat(label_wrap_length.min(width as usize))
+                    )?;
+                }
+                write!(output, " ┆ ")?;
+            } else {
+                text_wrap_length = width - 4;
+            }
+            if enable_color {
+                write!(output, "{}", text_style.paint(line.clone()))?;
+            } else {
+                write!(output, "{}", line.clone())?;
+            }
+            for _ in 0..(text_wrap_length - (line.len() as u16).min(text_wrap_length)) {
+                write!(output, " ")?;
+            }
+            write!(output, " │")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for Vulnerability {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}\n{}\n{}\n{}\n{}",
+            self.title, self.description, self.cvss_score, self.cvss_vector, self.reference
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn convert_output(output: &Vec<u8>) -> &str {
+        std::str::from_utf8(output.as_slice()).unwrap()
+    }
+
+    #[test]
+    fn test_title_style() {
+        let mut vulnerability = Vulnerability::default();
+        for score in 900..1000 {
+            vulnerability.cvss_score = (score / 100) as f32;
+            assert_eq!(
+                vulnerability.get_title_style(),
+                ansi_term::Color::Red.bold()
+            );
+        }
+        for score in 700..800 {
+            vulnerability.cvss_score = (score / 100) as f32;
+            assert_eq!(
+                vulnerability.get_title_style(),
+                ansi_term::Color::Red.normal()
+            );
+        }
+        for score in 400..600 {
+            vulnerability.cvss_score = (score / 100) as f32;
+            assert_eq!(
+                vulnerability.get_title_style(),
+                ansi_term::Color::Yellow.normal()
+            );
+        }
+    }
+
+    #[test]
+    fn test_divider() {
+        let mut output = Vec::new();
+        let vulnerability = Vulnerability::default();
+        vulnerability
+            .write_divider(&mut output, "-", "l", "r", "i", 20)
+            .expect("Failed to write output");
+        let mut line = convert_output(&output);
+        assert_eq!(line, "l-------------i----r");
+
+        output.clear();
+        vulnerability
+            .write_divider(&mut output, "-", "l", "r", "i", 40)
+            .expect("Failed to write output");
+        line = convert_output(&output);
+        assert_eq!(line, "l-------------i------------------------r");
+    }
+
+    #[test]
+    fn test_section_with_label() {
+        use ansi_term::Style;
+
+        let mut output = Vec::new();
+        let vulnerability = Vulnerability::default();
+        let style = Style::default();
+        vulnerability
+            .write_section(&mut output, Some("label"), "text", style, 30, false)
+            .expect("Failed to write output");
+        let line = convert_output(&output);
+        assert_eq!(line, "│       label ┆ text         │");
+    }
+
+    #[test]
+    fn test_section_without_label() {
+        use ansi_term::Style;
+
+        let mut output = Vec::new();
+        let vulnerability = Vulnerability::default();
+        let style = Style::default();
+        vulnerability
+            .write_section(&mut output, None, "text", style, 30, false)
+            .expect("Failed to write output");
+        let line = convert_output(&output);
+        assert_eq!(line, "│ text                       │");
+    }
+}


### PR DESCRIPTION
Added tabular display of vulnerabilities and used suggested format where possible to be consistent.

This pull request makes the following changes:
Adds tables to view
Adds coloring based on vulnerability level, consistent with Nancy.
Adds --no-color (-m) option 

It relates to the following issue #s:
* Implements #15
