### PR TITLE
Implement IQ Policy report output for scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
  "parking_lot",
  "regex",
  "serde",
- "serde-value 0.7.0",
+ "serde-value",
  "serde_json",
  "thiserror",
  "thread-id",
@@ -980,15 +980,6 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
@@ -1142,7 +1133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beb17280503804146233f15c98385d3c65f0330663ce0b602a1e4c9379e96b4d"
 dependencies = [
  "serde",
- "serde-value 0.6.0",
 ]
 
 [[package]]
@@ -1398,21 +1388,11 @@ dependencies = [
 
 [[package]]
 name = "serde-value"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
-dependencies = [
- "ordered-float 1.1.1",
- "serde",
-]
-
-[[package]]
-name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.7.0",
+ "ordered-float",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,6 @@ dependencies = [
  "mockito",
  "packageurl",
  "petgraph 0.5.1",
- "ptree",
  "quick-xml",
  "reqwest",
  "serde",
@@ -1124,15 +1123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "ptree"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb17280503804146233f15c98385d3c65f0330663ce0b602a1e4c9379e96b4d"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,18 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f1c3703dd33532d7f0ca049168930e9099ecac238e23cf932f3a69c42f06da"
 dependencies = [
- "serde 1.0.126",
+ "serde",
  "serde_json",
 ]
 
@@ -122,10 +116,10 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -146,7 +140,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
 dependencies = [
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -173,13 +167,13 @@ dependencies = [
  "ptree",
  "quick-xml",
  "reqwest",
- "serde 1.0.126",
+ "serde",
  "serde_derive",
  "serde_json",
  "terminal_size",
  "textwrap 0.13.4",
  "thiserror",
- "toml 0.4.10",
+ "toml",
  "url 1.7.2",
 ]
 
@@ -189,7 +183,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
 dependencies = [
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -213,7 +207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
 dependencies = [
  "semver 0.9.0",
- "serde 1.0.126",
+ "serde",
  "serde_derive",
  "serde_json",
 ]
@@ -228,7 +222,7 @@ dependencies = [
  "cargo-platform",
  "semver 0.11.0",
  "semver-parser 0.10.2",
- "serde 1.0.126",
+ "serde",
  "serde_json",
 ]
 
@@ -252,7 +246,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
  "time",
  "winapi",
 ]
@@ -302,24 +296,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi",
-]
-
-[[package]]
-name = "config"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
-dependencies = [
- "lazy_static 1.4.0",
- "nom",
- "rust-ini",
- "serde 1.0.126",
- "serde-hjson",
- "serde_json",
- "toml 0.5.8",
- "yaml-rust",
 ]
 
 [[package]]
@@ -329,7 +307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
 dependencies = [
  "encode_unicode",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "regex",
  "terminal_size",
@@ -363,7 +341,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -391,15 +369,6 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "directories"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
-dependencies = [
- "dirs-sys",
-]
 
 [[package]]
 name = "dirs"
@@ -735,7 +704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
  "console",
- "lazy_static 1.4.0",
+ "lazy_static",
  "number_prefix",
  "regex",
 ]
@@ -772,50 +741,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
 version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
-dependencies = [
- "serde 0.8.23",
- "serde_test",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -833,7 +767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -858,7 +792,7 @@ dependencies = [
  "log-mdc",
  "parking_lot",
  "regex",
- "serde 1.0.126",
+ "serde",
  "serde-value 0.7.0",
  "serde_json",
  "thiserror",
@@ -926,7 +860,7 @@ dependencies = [
  "colored",
  "difference",
  "httparse",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "rand",
  "regex",
@@ -940,7 +874,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -950,17 +884,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -979,16 +902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1070,7 +984,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1079,7 +993,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1227,14 +1141,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beb17280503804146233f15c98385d3c65f0330663ce0b602a1e4c9379e96b4d"
 dependencies = [
- "ansi_term 0.12.1",
- "atty",
- "config",
- "directories",
- "petgraph 0.5.1",
- "serde 1.0.126",
+ "serde",
  "serde-value 0.6.0",
- "tint",
 ]
 
 [[package]]
@@ -1375,13 +1283,13 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "mime",
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -1392,12 +1300,6 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
-
-[[package]]
-name = "rust-ini"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
@@ -1417,7 +1319,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi",
 ]
 
@@ -1457,7 +1359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser 0.7.0",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -1467,7 +1369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -1487,30 +1389,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-
-[[package]]
-name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static 1.4.0",
- "linked-hash-map 0.3.0",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
 ]
 
 [[package]]
@@ -1520,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 dependencies = [
  "ordered-float 1.1.1",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -1530,7 +1413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.7.0",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -1552,16 +1435,7 @@ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.126",
-]
-
-[[package]]
-name = "serde_test"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
-dependencies = [
- "serde 0.8.23",
+ "serde",
 ]
 
 [[package]]
@@ -1573,7 +1447,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -1605,12 +1479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,7 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
  "clap",
- "lazy_static 1.4.0",
+ "lazy_static",
  "structopt-derive",
 ]
 
@@ -1745,15 +1613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tint"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
-dependencies = [
- "lazy_static 0.2.11",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,16 +1673,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
- "serde 1.0.126",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -1849,7 +1699,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -1988,7 +1838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -2000,7 +1850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "proc-macro2",
  "quote",
@@ -2097,13 +1947,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map 0.5.4",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,6 @@ name = "cargo-pants"
 version = "0.2.2"
 dependencies = [
  "ansi_term 0.12.1",
- "atty",
  "cargo-tree",
  "cargo_metadata 0.13.1",
  "chrono",
@@ -157,7 +156,6 @@ dependencies = [
  "console",
  "dirs",
  "env_logger",
- "http",
  "indicatif",
  "log",
  "log4rs",
@@ -172,7 +170,6 @@ dependencies = [
  "terminal_size",
  "textwrap 0.13.4",
  "thiserror",
- "toml",
  "url 1.7.2",
 ]
 
@@ -1635,15 +1632,6 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,24 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,18 +93,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bstr"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,10 +117,7 @@ dependencies = [
 name = "cargo-pants"
 version = "0.2.2"
 dependencies = [
- "ansi_term 0.12.1",
- "cargo-tree",
- "cargo_metadata 0.13.1",
- "chrono",
+ "cargo_metadata",
  "clap",
  "cli-table",
  "console",
@@ -161,7 +128,7 @@ dependencies = [
  "log4rs",
  "mockito",
  "packageurl",
- "petgraph 0.5.1",
+ "petgraph",
  "quick-xml",
  "reqwest",
  "serde",
@@ -183,32 +150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-tree"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3370e91990a338fbaa50ef279d38b2eee711d6a928ab584adaa2551d8b822e8"
-dependencies = [
- "anyhow",
- "cargo_metadata 0.9.1",
- "petgraph 0.4.13",
- "semver 0.9.0",
- "serde_json",
- "structopt",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
-dependencies = [
- "semver 0.9.0",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "cargo_metadata"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,8 +157,8 @@ checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 0.11.0",
- "semver-parser 0.10.2",
+ "semver",
+ "semver-parser",
  "serde",
  "serde_json",
 ]
@@ -253,13 +194,9 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term 0.11.0",
- "atty",
  "bitflags",
- "strsim",
  "textwrap 0.11.0",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -268,21 +205,8 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84ed8652883003051b558c7f650be7668e68f73c9ef6574ba0be9119a2fec9d3"
 dependencies = [
- "cli-table-derive",
- "csv",
  "termcolor",
  "unicode-width",
-]
-
-[[package]]
-name = "cli-table-derive"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe942512e068e15991cbcef4e8182884555febbb21b5b4faf5dd5561850141a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -305,9 +229,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "regex",
  "terminal_size",
- "unicode-width",
  "winapi",
 ]
 
@@ -326,28 +248,6 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "derivative"
@@ -422,12 +322,6 @@ checksum = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
 dependencies = [
  "backtrace",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "fixedbitset"
@@ -556,15 +450,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -984,12 +869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordermap"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-
-[[package]]
 name = "packageurl"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,21 +926,11 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
-dependencies = [
- "fixedbitset 0.1.9",
- "ordermap",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset 0.2.0",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -1088,30 +957,6 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1223,12 +1068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,29 +1170,13 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -1443,36 +1266,6 @@ checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1706,12 +1499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,18 +1547,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ cli-table = "0.4.6"
 log4rs = { version = "1.0.0", default-features = false, features = ["json_encoder", "config_parsing", "file_appender"] }
 dirs = "3.0.2"
 cargo_metadata = "0.13.1"
-ptree = { version = "0.3.2", default-features = false }
 cargo-tree = "0.29.0"
 petgraph = "0.5.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ name = "cargo-iq"
 path = "src/bin/iq.rs"
 
 [dependencies]
-ansi_term = "0.12.1"
-chrono = { version = "0.4", optional = true }
-clap = "2.32.0"
+clap = { version = "2.32.0", default-features = false }
 log = "0.4.0"
 packageurl = "0.2.0"
 reqwest = { version = "0.11.4", features = ["json", "blocking"] }
@@ -30,14 +28,13 @@ terminal_size = "0.1.17"
 textwrap = "0.13.4"
 thiserror = "1.0.25"
 url = "1.7.0"
-quick-xml = "0.22.0"
-indicatif = "0.16.2"
-console = "0.14.1"
-cli-table = "0.4.6"
+quick-xml = { version = "0.22.0", default-features = false }
+indicatif = { version = "0.16.2", default-features = false }
+console = { version = "0.14.1", default-features = false }
+cli-table = { version = "0.4.6", default-features = false }
 log4rs = { version = "1.0.0", default-features = false, features = ["json_encoder", "config_parsing", "file_appender"] }
 dirs = "3.0.2"
 cargo_metadata = "0.13.1"
-cargo-tree = "0.29.0"
 petgraph = "0.5.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ cli-table = "0.4.6"
 log4rs = { version = "1.0.0", default-features = false, features = ["json_encoder", "config_parsing", "file_appender"] }
 dirs = "3.0.2"
 cargo_metadata = "0.13.1"
-ptree = { version = "0.3.2", default-features = false, features = ["value"] }
+ptree = { version = "0.3.2", default-features = false }
 cargo-tree = "0.29.0"
 petgraph = "0.5.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,8 @@ path = "src/bin/iq.rs"
 
 [dependencies]
 ansi_term = "0.12.1"
-atty = "0.2"
 chrono = { version = "0.4", optional = true }
 clap = "2.32.0"
-env_logger = "0.6.1"
-http = "0.2.4"
 log = "0.4.0"
 packageurl = "0.2.0"
 reqwest = { version = "0.11.4", features = ["json", "blocking"] }
@@ -32,7 +29,6 @@ serde_json = "1.0.16"
 terminal_size = "0.1.17"
 textwrap = "0.13.4"
 thiserror = "1.0.25"
-toml = "0.4"
 url = "1.7.0"
 quick-xml = "0.22.0"
 indicatif = "0.16.2"
@@ -45,4 +41,5 @@ cargo-tree = "0.29.0"
 petgraph = "0.5.1"
 
 [dev-dependencies]
+env_logger = "0.6.1"
 mockito = "0.30.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ cli-table = "0.4.6"
 log4rs = { version = "1.0.0", default-features = false, features = ["json_encoder", "config_parsing", "file_appender"] }
 dirs = "3.0.2"
 cargo_metadata = "0.13.1"
-ptree = "0.3"
+ptree = { version = "0.3.2", default-features = false, features = ["value"] }
 cargo-tree = "0.29.0"
 petgraph = "0.5.1"
 

--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,10 @@ cargo-pants
 Copyright 2019 Glenn Mohre, Sonatype.
 
 This product includes software developed by authors of https://github.com/sfackler/cargo-tree and 
-contains code derived from that project package distributed on GitHub. The software has been modified to:
+contains code derived from that project package distributed on GitHub. The project is dual licensed as 
+Apache and MIT, and compatible with the Apache license used on this project.
+
+The software has been modified to:
 
 - Use the types we are using
 - Customize how the graph is constructed

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+cargo-pants
+Copyright 2019 Glenn Mohre, Sonatype.
+
+This product includes software developed by authors of https://github.com/sfackler/cargo-tree and 
+contains code derived from that project package distributed on GitHub. The software has been modified to:
+
+- Use the types we are using
+- Customize how the graph is constructed
+- Output the inverse graph
+
+The original code and repository can be found at: https://github.com/sfackler/cargo-tree

--- a/src/bin/iq.rs
+++ b/src/bin/iq.rs
@@ -252,17 +252,7 @@ fn print_iq_policy_violations(res: PolicyReportResult, parser: &impl ParseToml) 
         .components
         .clone()
         .into_iter()
-        .filter(|p| {
-            if p.violations
-                .as_ref()
-                .unwrap_or(&(vec![] as Vec<Violation>))
-                .is_empty()
-            {
-                return false;
-            } else {
-                return true;
-            }
-        })
+        .filter(|p| p.violations.as_ref().map_or(false, |v| !v.is_empty()))
         .collect();
 
     if policy_violations.len() > 0 {

--- a/src/bin/iq.rs
+++ b/src/bin/iq.rs
@@ -265,7 +265,10 @@ fn print_iq_policy_violations(res: PolicyReportResult, parser: &impl ParseToml) 
         .collect();
 
     if policy_violations.len() > 0 {
-        println!("Components ({}) with policy violations found", policy_violations.len());
+        println!(
+            "Components ({}) with policy violations found",
+            policy_violations.len()
+        );
         println!("");
 
         for comp in policy_violations {
@@ -287,7 +290,7 @@ fn print_iq_policy_violations(res: PolicyReportResult, parser: &impl ParseToml) 
                 None => {}
             }
         }
-    
+
         println!();
     }
 }

--- a/src/bin/iq.rs
+++ b/src/bin/iq.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Glenn Mohre.
+// Copyright 2019 Glenn Mohre, Sonatype.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bin/iq.rs
+++ b/src/bin/iq.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #[macro_use]
 extern crate clap;
 

--- a/src/bin/iq.rs
+++ b/src/bin/iq.rs
@@ -270,10 +270,7 @@ fn print_iq_policy_violations(res: PolicyReportResult, parser: &impl ParseToml) 
                         "Known violations: {}",
                         violations
                             .into_iter()
-                            .map(
-                                |v| policy_violation_to_styled_object(v.policy_name as String)
-                                    .to_string()
-                            )
+                            .map(|v| policy_violation_to_styled_object(v.policy_name).to_string())
                             .collect::<Vec<String>>()
                             .join(",")
                     );

--- a/src/bin/iq.rs
+++ b/src/bin/iq.rs
@@ -264,27 +264,32 @@ fn print_iq_policy_violations(res: PolicyReportResult, parser: &impl ParseToml) 
         })
         .collect();
 
-    for comp in policy_violations {
-        println!("Package URL: {}", comp.package_url);
-        match comp.violations {
-            Some(violations) => {
-                println!(
-                    "\tKnown violations: {}",
-                    violations
-                        .into_iter()
-                        .map(|v| v.policy_name as String)
-                        .collect::<Vec<String>>()
-                        .join(",")
-                );
-                println!("\tInverse Dependency graph");
-                assert!(parser.print_the_graph(comp.package_url).is_ok());
-                println!("");
-            }
-            None => {}
-        }
-    }
+    if policy_violations.len() > 0 {
+        println!("Components ({}) with policy violations found", policy_violations.len());
+        println!("");
 
-    println!();
+        for comp in policy_violations {
+            println!("Package URL: {}", comp.package_url);
+            match comp.violations {
+                Some(violations) => {
+                    println!(
+                        "\tKnown violations: {}",
+                        violations
+                            .into_iter()
+                            .map(|v| v.policy_name as String)
+                            .collect::<Vec<String>>()
+                            .join(",")
+                    );
+                    println!("\tInverse Dependency graph");
+                    assert!(parser.print_the_graph(comp.package_url).is_ok());
+                    println!("");
+                }
+                None => {}
+            }
+        }
+    
+        println!();
+    }
 }
 
 fn print_iq_summary(

--- a/src/bin/iq.rs
+++ b/src/bin/iq.rs
@@ -276,14 +276,17 @@ fn print_iq_policy_violations(res: PolicyReportResult, parser: &impl ParseToml) 
             match comp.violations {
                 Some(violations) => {
                     println!(
-                        "\tKnown violations: {}",
+                        "Known violations: {}",
                         violations
                             .into_iter()
-                            .map(|v| v.policy_name as String)
+                            .map(
+                                |v| policy_violation_to_styled_object(v.policy_name as String)
+                                    .to_string()
+                            )
                             .collect::<Vec<String>>()
                             .join(",")
                     );
-                    println!("\tInverse Dependency graph");
+                    println!("Inverse Dependency graph");
                     assert!(parser.print_the_graph(comp.package_url).is_ok());
                     println!("");
                 }
@@ -292,6 +295,15 @@ fn print_iq_policy_violations(res: PolicyReportResult, parser: &impl ParseToml) 
         }
 
         println!();
+    }
+}
+
+fn policy_violation_to_styled_object(violation: String) -> StyledObject<String> {
+    // TODO: Implement the rest of the violation types to colors?
+    match violation.as_ref() {
+        "Security-Critical" => style(violation).red().bold(),
+        "Security-Medium" => style(violation).yellow().bold(),
+        &_ => style(violation).dim(),
     }
 }
 

--- a/src/bin/pants.rs
+++ b/src/bin/pants.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Glenn Mohre.
+// Copyright 2019 Glenn Mohre, Sonatype.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bin/pants.rs
+++ b/src/bin/pants.rs
@@ -193,7 +193,7 @@ fn write_package_output(
                 "[{}/{}] {}",
                 index + 1,
                 package_count,
-                get_purl_color(vulnerable, coordinate.purl.clone())
+                style_purl(vulnerable, coordinate.purl.clone())
             )?;
         } else {
             writeln!(
@@ -235,10 +235,10 @@ fn write_package_output(
     Ok(())
 }
 
-fn get_purl_color(vulnerable: bool, val: String) -> StyledObject<String> {
+fn style_purl(vulnerable: bool, purl: String) -> StyledObject<String> {
     match vulnerable {
-        true => style(val).red().bold(),
-        false => style(val).green(),
+        true => style(purl).red().bold(),
+        false => style(purl).green(),
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Glenn Mohre.
+// Copyright 2019 Glenn Mohre, Sonatype.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/client.rs
+++ b/src/client.rs
@@ -115,12 +115,11 @@ impl UrlMaker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use env_logger::builder;
     use mockito::mock;
 
-    extern crate env_logger;
-
     fn init_logger() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = builder().is_test(true).try_init();
     }
 
     #[test]

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -24,30 +24,6 @@ impl Coordinate {
         }
         score
     }
-
-    pub fn get_threat_color(&self) -> Option<ansi_term::Color> {
-        use ansi_term::Color;
-
-        match self.get_threat_score() {
-            9..=10 => Some(Color::Red),
-            7..=8 => Some(Color::Red),
-            4..=6 => Some(Color::Yellow),
-            _ => None,
-        }
-    }
-
-    pub fn get_threat_format(&self) -> ansi_term::Style {
-        use ansi_term::{Color, Style};
-
-        let color: Option<Color> = self.get_threat_color();
-        match color {
-            Some(value) => match self.get_threat_score() {
-                9..=10 => value.bold(),
-                _ => value.normal(),
-            },
-            None => Style::default(),
-        }
-    }
 }
 
 impl fmt::Display for Coordinate {

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -1,3 +1,17 @@
+// Copyright 2019 Glenn Mohre, Sonatype.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::Vulnerability;
 use std::fmt;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Glenn Mohre.
+// Copyright 2019 Glenn Mohre, Sonatype.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -28,14 +28,6 @@ pub struct ApplicationResponse {
 
 #[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Application {
-    pub id: String,
-    pub public_id: String,
-    pub name: String,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ApplicationTag {
     pub id: String,
     pub tag_id: String,
@@ -87,37 +79,6 @@ pub struct RawReportResults {
 
 #[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Component {
-    pub hash: String,
-    pub component_identifier: ComponentIdentifier,
-    pub package_url: String,
-    pub proprietary: bool,
-    pub match_state: String,
-    pub pathnames: Vec<String>,
-    pub license_data: LicenseData,
-    pub security_data: SecurityData,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ComponentIdentifier {
-    pub format: String,
-    pub coordinates: Coordinates,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Coordinates {
-    pub artifact_id: Option<String>,
-    pub name: Option<String>,
-    pub group_id: Option<String>,
-    pub version: String,
-    pub extension: Option<String>,
-    pub classifier: Option<String>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct LicenseData {
     pub declared_licenses: Vec<DeclaredLicense>,
     pub observed_licenses: Vec<ObservedLicense>,
@@ -164,9 +125,122 @@ pub struct SecurityIssue {
     pub threat_category: String,
 }
 
+// POLICY REPORT
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyReportResult {
+    pub report_time: i64,
+    pub report_title: String,
+    pub commit_hash: Option<String>,
+    pub initiator: String,
+    pub application: Application,
+    pub counts: Counts,
+    pub components: Vec<Component>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Application {
+    pub id: String,
+    pub public_id: String,
+    pub name: String,
+    pub organization_id: Option<String>,
+    pub contact_user_name: Option<String>,
+    pub application_tags: Option<Vec<ApplicationTag>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Counts {
+    pub partially_matched_component_count: i64,
+    pub exactly_matched_component_count: i64,
+    pub total_component_count: i64,
+    pub grandfathered_policy_violation_count: i64,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Component {
+    pub hash: String,
+    pub match_state: String,
+    pub component_identifier: ComponentIdentifier,
+    pub package_url: String,
+    pub proprietary: bool,
+    pub pathnames: Vec<String>,
+    pub dependency_data: Option<DependencyData>,
+    pub violations: Option<Vec<Violation>>,
+    pub display_name: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentIdentifier {
+    pub format: String,
+    pub coordinates: Coordinates,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Coordinates {
+    pub artifact_id: Option<String>,
+    pub name: Option<String>,
+    pub group_id: Option<String>,
+    pub version: String,
+    pub extension: Option<String>,
+    pub classifier: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyData {
+    pub direct_dependency: bool,
+    pub inner_source: bool,
+    #[serde(default)]
+    pub inner_source_data: Vec<InnerSourceDaum>,
+    pub parent_component_purls: Option<Vec<String>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InnerSourceDaum {
+    pub owner_application_name: String,
+    pub owner_application_id: String,
+    pub inner_source_component_purl: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Violation {
+    pub policy_id: String,
+    pub policy_name: String,
+    pub policy_threat_category: String,
+    pub policy_threat_level: i64,
+    pub policy_violation_id: String,
+    pub waived: bool,
+    pub grandfathered: bool,
+    pub constraints: Vec<Constraint>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Constraint {
+    pub constraint_id: String,
+    pub constraint_name: String,
+    pub conditions: Vec<Condition>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition {
+    pub condition_summary: String,
+    pub condition_reason: String,
+}
+
 pub struct ReportResults {
     pub url_results: StatusURLResult,
     pub data_results: RawReportResults,
+    pub policy_report_results: PolicyReportResult,
 }
 
 #[derive(Debug)]
@@ -250,13 +324,16 @@ impl IQClient {
             };
 
             let result = self.poll_status_url(status_url_string.to_string());
+
             if result.is_ok() {
                 let res = result.unwrap();
                 let data = self.get_raw_report_results(res.report_data_url.clone());
+                let policy = self.get_policy_report_results(res.report_data_url.clone());
 
                 if data.is_ok() {
                     let combined_results: ReportResults = ReportResults {
                         data_results: data.unwrap(),
+                        policy_report_results: policy.unwrap(),
                         url_results: res,
                     };
                     return Ok(combined_results);
@@ -266,9 +343,8 @@ impl IQClient {
             }
             if result.is_err() {
                 let res_err = result.unwrap_err();
-                let status = res_err.status().unwrap();
-                if status.is_client_error() {
-                    match status {
+                if res_err.is_status() {
+                    match res_err.status().unwrap() {
                         StatusCode::NOT_FOUND => {
                             i = i + 1;
 
@@ -335,6 +411,7 @@ impl IQClient {
 
         let url_string = format!("{}/{}", &self.server, &status_url);
         let url = Url::parse(&url_string).unwrap();
+
         let res = client
             .get(url)
             .basic_auth(&self.user.to_string(), Some(&self.token.to_string()))
@@ -351,6 +428,27 @@ impl IQClient {
 
         let url_string = format!("{}/{}", &self.server, &report_url);
         let url = Url::parse(&url_string).unwrap();
+        let res = client
+            .get(url)
+            .basic_auth(&self.user.to_string(), Some(&self.token.to_string()))
+            .send()?;
+
+        return res.json();
+    }
+
+    fn get_policy_report_results(
+        &self,
+        report_url: String,
+    ) -> Result<PolicyReportResult, reqwest::Error> {
+        let client = Client::new();
+
+        let url_string = format!(
+            "{}/{}",
+            &self.server,
+            &report_url.replace("/raw", "/policy")
+        );
+        let url = Url::parse(&url_string).unwrap();
+
         let res = client
             .get(url)
             .basic_auth(&self.user.to_string(), Some(&self.token.to_string()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Glenn Mohre.
+// Copyright 2019 Glenn Mohre, Sonatype.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ extern crate url;
 
 #[macro_use]
 extern crate serde_derive;
-extern crate env_logger;
 extern crate log;
 extern crate serde_json;
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Glenn Mohre.
+// Copyright 2019 Glenn Mohre, Sonatype.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Sonatype.
+// Copyright 2021 Sonatype, and Authors of https://github.com/sfackler/cargo-tree.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -1,3 +1,17 @@
+// Copyright 2019 Glenn Mohre, Sonatype.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use console::style;
 use console::StyledObject;
 use std::fmt;

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -1,3 +1,5 @@
+use console::style;
+use console::StyledObject;
 use std::fmt;
 use std::io::Write;
 
@@ -12,12 +14,12 @@ pub struct Vulnerability {
 }
 
 impl Vulnerability {
-    fn get_title_style(&self) -> ansi_term::Style {
+    fn print_value_with_color(&self, value: String) -> StyledObject<String> {
         match self.cvss_score as u8 {
-            9..=10 => ansi_term::Color::Red.bold(),
-            7..=8 => ansi_term::Color::Red.normal(),
-            4..=6 => ansi_term::Color::Yellow.normal(),
-            _ => ansi_term::Style::default(),
+            9..=10 => style(value).red().bold(),
+            7..=8 => style(value).red(),
+            4..=6 => style(value).yellow(),
+            _ => style(value).green(),
         }
     }
 
@@ -27,8 +29,6 @@ impl Vulnerability {
         enable_color: bool,
         width_override: Option<u16>,
     ) -> std::io::Result<()> {
-        use ansi_term::Style;
-
         let width = match width_override {
             Some(width) => width,
             None => crate::calculate_term_width(),
@@ -36,14 +36,7 @@ impl Vulnerability {
 
         self.write_divider(output, "─", "╭", "╮", "─", width)?;
 
-        self.write_section(
-            output,
-            None,
-            &self.title,
-            self.get_title_style(),
-            width,
-            enable_color,
-        )?;
+        self.write_section(output, None, &self.title, width, enable_color)?;
 
         self.write_divider(output, "─", "├", "┤", "┬", width)?;
 
@@ -51,7 +44,6 @@ impl Vulnerability {
             output,
             Some("Description"),
             &self.description,
-            Style::default(),
             width,
             enable_color,
         )?;
@@ -61,7 +53,6 @@ impl Vulnerability {
             output,
             Some("CVSS Score"),
             &self.cvss_score.to_string(),
-            Style::default(),
             width,
             enable_color,
         )?;
@@ -71,7 +62,6 @@ impl Vulnerability {
             output,
             Some("CVSS Vector"),
             &self.cvss_vector,
-            Style::default(),
             width,
             enable_color,
         )?;
@@ -81,7 +71,6 @@ impl Vulnerability {
             output,
             Some("Reference"),
             &self.reference,
-            Style::default(),
             width,
             enable_color,
         )?;
@@ -114,7 +103,6 @@ impl Vulnerability {
         output: &mut dyn Write,
         label: Option<&str>,
         text: &str,
-        text_style: ansi_term::Style,
         width: u16,
         enable_color: bool,
     ) -> std::io::Result<()> {
@@ -151,7 +139,11 @@ impl Vulnerability {
                 text_wrap_length = width - 4;
             }
             if enable_color {
-                write!(output, "{}", text_style.paint(line.clone()))?;
+                write!(
+                    output,
+                    "{}",
+                    self.print_value_with_color(line.to_string().clone())
+                )?;
             } else {
                 write!(output, "{}", line.clone())?;
             }
@@ -184,32 +176,6 @@ mod tests {
     }
 
     #[test]
-    fn test_title_style() {
-        let mut vulnerability = Vulnerability::default();
-        for score in 900..1000 {
-            vulnerability.cvss_score = (score / 100) as f32;
-            assert_eq!(
-                vulnerability.get_title_style(),
-                ansi_term::Color::Red.bold()
-            );
-        }
-        for score in 700..800 {
-            vulnerability.cvss_score = (score / 100) as f32;
-            assert_eq!(
-                vulnerability.get_title_style(),
-                ansi_term::Color::Red.normal()
-            );
-        }
-        for score in 400..600 {
-            vulnerability.cvss_score = (score / 100) as f32;
-            assert_eq!(
-                vulnerability.get_title_style(),
-                ansi_term::Color::Yellow.normal()
-            );
-        }
-    }
-
-    #[test]
     fn test_divider() {
         let mut output = Vec::new();
         let vulnerability = Vulnerability::default();
@@ -229,13 +195,10 @@ mod tests {
 
     #[test]
     fn test_section_with_label() {
-        use ansi_term::Style;
-
         let mut output = Vec::new();
         let vulnerability = Vulnerability::default();
-        let style = Style::default();
         vulnerability
-            .write_section(&mut output, Some("label"), "text", style, 30, false)
+            .write_section(&mut output, Some("label"), "text", 30, false)
             .expect("Failed to write output");
         let line = convert_output(&output);
         assert_eq!(line, "│       label ┆ text         │");
@@ -243,13 +206,10 @@ mod tests {
 
     #[test]
     fn test_section_without_label() {
-        use ansi_term::Style;
-
         let mut output = Vec::new();
         let vulnerability = Vulnerability::default();
-        let style = Style::default();
         vulnerability
-            .write_section(&mut output, None, "text", style, 30, false)
+            .write_section(&mut output, None, "text", 30, false)
             .expect("Failed to write output");
         let line = convert_output(&output);
         assert_eq!(line, "│ text                       │");


### PR DESCRIPTION
This adds the IQ Policy Report data, and starts to output it!

This pull request makes the following changes:
* Adds endpoint in `src/iq.rs`, also fixes `reqwest` issue brought on by upgrade of `reqwest`
* Adds a function to print the policy_violations, outputting the purl, the policy violations that occurred, and then the inverse dependency graph
* Removes `ptree` dependency, as this was a left over of testing some things out with the dependency graph that I forgot to nix, but this work pointed out!

<img width="992" alt="Screen Shot 2021-07-21 at 9 31 49 PM" src="https://user-images.githubusercontent.com/5544326/126593865-5a191e98-82f3-4fe6-9f23-3c8661f077bb.png">

It relates to the following issue #s:
* Fixes #48 
