### PR TITLE
Set MSRV, and up to 1.53 due to issues with net library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,10 @@ jobs:
           key: cargo-pants-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Check formatting
-          command: cargo fmt -- --check
+          command: rustup run nightly cargo fmt -- --check
       - run:
           name: Build all targets
-          command: cargo build --all --all-targets
+          command: rustup run nightly cargo build --all --all-targets
       - save_cache:
           key: cargo-pants-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
@@ -44,13 +44,13 @@ jobs:
             - "./target"
       - run:
           name: Run all tests
-          command: cargo test --all
+          command: rustup run nightly cargo test --all
       - run:
           name: Dogfood with locally built Cargo Pants
           command: ./target/debug/cargo-pants pants
       - run:
           name: Install Cargo Pants as Cargo Subcommand
-          command: cargo install cargo-pants --force
+          command: rustup run nightly cargo install cargo-pants --force
       - run:
           name: Dogfood Cargo Pants
           command: cargo pants

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - run:
           name: Calculate dependencies
-          command: cargo generate-lockfile
+          command: rustup run nightly cargo generate-lockfile
       - restore_cache:
           key: cargo-pants-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,22 +24,16 @@ jobs:
           name: Version information
           command: rustc --version; cargo --version; rustup --version
       - run:
-          name: Install nightly
-          command: rustup install nightly
-      - run:
-          name: Install fmt
-          command: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
-      - run:
           name: Calculate dependencies
-          command: rustup run nightly cargo generate-lockfile
+          command: cargo generate-lockfile
       - restore_cache:
           key: cargo-pants-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Check formatting
-          command: rustup run nightly cargo fmt -- --check
+          command: cargo fmt -- --check
       - run:
           name: Build all targets
-          command: rustup run nightly cargo build --all --all-targets
+          command: cargo build --all --all-targets
       - save_cache:
           key: cargo-pants-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
@@ -47,13 +41,13 @@ jobs:
             - "./target"
       - run:
           name: Run all tests
-          command: rustup run nightly cargo test --all
+          command: cargo test --all
       - run:
           name: Dogfood with locally built Cargo Pants
           command: ./target/debug/cargo-pants pants
       - run:
           name: Install Cargo Pants as Cargo Subcommand
-          command: rustup run nightly cargo install cargo-pants --force
+          command: cargo install cargo-pants --force
       - run:
           name: Dogfood Cargo Pants
           command: cargo pants

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
           name: Install nightly
           command: rustup install nightly
       - run:
+          name: Install fmt
+          command: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+      - run:
           name: Calculate dependencies
           command: rustup run nightly cargo generate-lockfile
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
           name: Version information
           command: rustc --version; cargo --version; rustup --version
       - run:
+          name: Install nightly
+          command: rustup install nightly
+      - run:
           name: Calculate dependencies
           command: rustup run nightly cargo generate-lockfile
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   circleci-rust-docker:
     docker:
-      - image: circleci/rust:1.49.0
+      - image: circleci/rust:1.53.0
 
 jobs:
   release:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rust-version"]
+
 [package]
 name = "cargo-pants"
 version = "0.3.2"
@@ -7,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/sonatype-nexus-community/cargo-pants"
 description = "cargo-pants is a cargo subcommand application that provides a bill of materials and a list of which dependencies have a vulnerability, powered by Sonatype OSSIndex"
 license = "Apache-2.0"
-rust = "1.53"
+rust-version = "1.53"
 
 [[bin]]
 name = "cargo-pants"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 repository = "https://github.com/sonatype-nexus-community/cargo-pants"
 description = "cargo-pants is a cargo subcommand application that provides a bill of materials and a list of which dependencies have a vulnerability, powered by Sonatype OSSIndex"
 license = "Apache-2.0"
+rust = "1.53"
 
 [[bin]]
 name = "cargo-pants"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["rust-version"]
-
 [package]
 name = "cargo-pants"
 version = "0.3.2"


### PR DESCRIPTION
There are issues with the net library prior to 1.53, and it is likely we use it, so this move is mostly a) let's just move up to MSRV of 1.53 to avoid a lengthy look at if we are totally affected.

This pull request makes the following changes:
* Build using `1.53` in CircleCI
* Set `rust-version = 1.53` in `Cargo.toml`

Build failure fixed now that we can ignore a vulnerability (done in #57 )