### PR TITLE
Replace log4rs with tracing

### DIFF
--- a/.pants-ignore
+++ b/.pants-ignore
@@ -1,8 +1,3 @@
 {
-  "ignore": [
-    { 
-      "id": "090a08dc-6a51-4073-b874-d71193524758", 
-      "reason": "We have no way to get past the time vulnerability at this point in time, har har." 
-    }
-  ]
+  "ignore": [ ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,16 +21,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.42"
+name = "ansi_term"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
-
-[[package]]
-name = "arc-swap"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -101,8 +98,6 @@ dependencies = [
  "dirs",
  "env_logger",
  "indicatif",
- "log",
- "log4rs",
  "mockito",
  "packageurl",
  "petgraph",
@@ -117,6 +112,8 @@ dependencies = [
  "terminal_size",
  "textwrap 0.14.2",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -155,25 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -221,17 +205,6 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "difference"
@@ -538,15 +511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,52 +544,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
-name = "lock_api"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
- "serde",
 ]
 
 [[package]]
-name = "log-mdc"
+name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
-
-[[package]]
-name = "log4rs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1572a880d1115ff867396eee7ae2bc924554225e67a0d3c85c745b3e60ca211"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "anyhow",
- "arc-swap",
- "chrono",
- "derivative",
- "fnv",
- "humantime",
- "log",
- "log-mdc",
- "parking_lot",
- "regex",
- "serde",
- "serde-value",
- "serde_json",
- "thiserror",
- "thread-id",
- "typemap",
+ "regex-automata",
 ]
 
 [[package]]
@@ -714,25 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,15 +702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "packageurl"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,31 +709,6 @@ checksum = "c53362339d1c48910f1b0c35e2ae96e2d32e442c7dc3ac5f622908ec87221f08"
 dependencies = [
  "percent-encoding",
  "thiserror",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.9",
- "smallvec",
- "winapi",
 ]
 
 [[package]]
@@ -964,12 +844,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
@@ -984,7 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.9",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -995,6 +869,15 @@ checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -1065,12 +948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "security-framework"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,16 +989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1153,6 +1020,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1233,7 +1109,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand",
- "redox_syscall 0.2.9",
+ "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
@@ -1309,24 +1185,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "3.3.0"
+name = "thread_local"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "libc",
- "redox_syscall 0.1.57",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
+ "once_cell",
 ]
 
 [[package]]
@@ -1392,44 +1256,83 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
+name = "tracing-attributes"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
+name = "tracing-log"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
+dependencies = [
+ "ansi_term 0.12.1",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
 
 [[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
-dependencies = [
- "unsafe-any",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -1475,15 +1378,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
-]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,21 @@ cargo_metadata = "0.14.1"
 console = { version = "0.15.0", default-features = false }
 dirs = "4.0.0"
 indicatif = { version = "0.16.2", default-features = false }
-log = "0.4.0"
-log4rs = { version = "1.0.0", default-features = false, features = ["json_encoder", "config_parsing", "file_appender"] }
 packageurl = "0.3.0"
 petgraph = "0.6.0"
+quick-xml = { version = "0.22.0", default-features = false }
 reqwest = { version = "0.11.6", features = ["json", "blocking"] }
 semver = "1.0.4"
 serde = "1.0.130"
 serde_derive = "1.0.130"
-serde_json = "1.0.68"
+serde_json = "1.0.69"
 structopt = "0.3.25"
 term-table = "1.3.2"
 terminal_size = "0.1.17"
 textwrap = "0.14.2"
 thiserror = "1.0.30"
-quick-xml = { version = "0.22.0", default-features = false }
+tracing = "0.1.29"
+tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 url = "2.2.2"
 
 [dev-dependencies]

--- a/src/bin/iq/cli.rs
+++ b/src/bin/iq/cli.rs
@@ -15,8 +15,8 @@
 use std::path::PathBuf;
 
 use crate::common;
-use log::LevelFilter;
 use structopt::StructOpt;
+use tracing_subscriber::filter::EnvFilter;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -64,7 +64,7 @@ pub enum Opt {
 
         /// Set the verbosity of the logger, more is more verbose, so -vvvv is more verbose than -v
         #[structopt(short = "v", long = "verbose", parse(from_occurrences = common::parse_log_level))]
-        log_level: LevelFilter,
+        log_level: EnvFilter,
 
         /// A flag to include dev dependencies
         #[structopt(long = "dev")]

--- a/src/bin/iq/main.rs
+++ b/src/bin/iq/main.rs
@@ -23,11 +23,11 @@ use cargo_pants::ParseToml;
 use console::StyledObject;
 use console::{style, Emoji};
 use indicatif::{ProgressBar, ProgressStyle};
-use log::{debug, error, trace};
 use std::{env, process};
 use structopt::StructOpt;
 use term_table::row::Row;
 use term_table::table_cell::TableCell;
+use tracing::{debug, error, trace};
 
 #[path = "../../common.rs"]
 mod common;
@@ -60,7 +60,7 @@ fn main() {
                 env!("CARGO_BIN_NAME").to_string(),
                 env!("CARGO_PKG_VERSION").to_string(),
             );
-            common::construct_logger(true, log_level);
+            common::construct_logger(".iqserver", log_level);
             common::print_dev_dependencies_info(include_dev_dependencies);
 
             let spinner_style =

--- a/src/bin/pants/cli.rs
+++ b/src/bin/pants/cli.rs
@@ -15,8 +15,8 @@
 use std::path::PathBuf;
 
 use crate::common;
-use log::LevelFilter;
 use structopt::StructOpt;
+use tracing_subscriber::filter::EnvFilter;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -37,7 +37,7 @@ pub enum Opt {
 
         /// Set the verbosity of the logger, more is more verbose, so -vvvv is more verbose than -v
         #[structopt(short = "v", long = "verbose", parse(from_occurrences = common::parse_log_level))]
-        log_level: LevelFilter,
+        log_level: EnvFilter,
 
         /// A flag to include dev dependencies
         #[structopt(long = "dev")]

--- a/src/bin/pants/main.rs
+++ b/src/bin/pants/main.rs
@@ -19,13 +19,13 @@ use cargo_pants::{client::OSSIndexClient, coordinate::Coordinate};
 use console::style;
 use console::StyledObject;
 use structopt::StructOpt;
+use tracing::info;
 
 use std::io::{stdout, Write};
 use std::path::PathBuf;
 use std::{env, io, process};
 
 #[path = "../../common.rs"]
-#[macro_use]
 mod common;
 
 mod cli;
@@ -44,7 +44,7 @@ fn main() {
             oss_index_api_key,
             ignore_file,
         } => {
-            common::construct_logger(false, log_level);
+            common::construct_logger(".ossindex", log_level);
 
             if let Some(pants_style) = pants_style {
                 check_pants(&pants_style);
@@ -84,7 +84,7 @@ fn audit(
     let api_key = match oss_index_api_key {
         Some(oss_index_api_key) => oss_index_api_key,
         None => {
-            log::info!("Warning: missing optional 'OSS_INDEX_API_KEY'");
+            info!("Warning: missing optional 'OSS_INDEX_API_KEY'");
             String::new()
         }
     };
@@ -160,7 +160,11 @@ fn write_package_output(
     width_override: Option<u16>,
     parser: &impl ParseToml,
 ) -> io::Result<()> {
-    let vulnerability = ternary!(vulnerable, "Vulnerable", "Non-vulnerable");
+    let vulnerability = if vulnerable {
+        "Vulnerable"
+    } else {
+        "Non-vulnerable"
+    };
 
     writeln!(output, "\n{} Dependencies\n", vulnerability)?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,10 +13,9 @@
 // limitations under the License.
 use std::collections::HashMap;
 
-#[allow(unused_imports)]
-use log::{debug, error};
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
+use tracing::debug;
 use url::Url;
 
 use crate::{coordinate::Coordinate, package::Package};

--- a/src/common.rs
+++ b/src/common.rs
@@ -13,23 +13,9 @@
 // limitations under the License.
 
 use dirs::home_dir;
-use log::LevelFilter;
-use log4rs::append::file::FileAppender;
-use log4rs::config::Appender;
-use log4rs::config::Logger;
-use log4rs::config::Root;
-use log4rs::encode::json::JsonEncoder;
-use log4rs::Config;
-
-macro_rules! ternary {
-    ($c:expr, $v:expr, $v1:expr) => {
-        if $c {
-            $v
-        } else {
-            $v1
-        }
-    };
-}
+use std::fs::OpenOptions;
+use std::sync::Mutex;
+use tracing_subscriber::filter::EnvFilter;
 
 pub static CARGO_DEFAULT_TOMLFILE: &str = "Cargo.toml";
 
@@ -47,42 +33,52 @@ pub fn print_dev_dependencies_info(dev: bool) {
     println!();
 }
 
-pub fn parse_log_level(verbosity: u64) -> LevelFilter {
-    return match verbosity {
-        1 => LevelFilter::Warn,
-        2 => LevelFilter::Info,
-        3 => LevelFilter::Debug,
-        4 => LevelFilter::Trace,
-        _ => LevelFilter::Error,
-    };
+pub fn parse_log_level(verbosity: u64) -> EnvFilter {
+    match verbosity {
+        0 => env_filter_at_level("error"),
+        1 => env_filter_at_level("warn"),
+        2 => env_filter_at_level("info"),
+        3 => env_filter_at_level("debug"),
+        4 => env_filter_at_level("trace"),
+        _ => EnvFilter::from_default_env(),
+    }
 }
 
-pub fn construct_logger(iq: bool, log_level_filter: LevelFilter) {
+fn env_filter_at_level(level: &str) -> EnvFilter {
+    EnvFilter::default()
+        .add_directive(
+            format!("cargo_pants={}", level)
+                .parse()
+                .expect("Failed to parse level directive"),
+        )
+        .add_directive(
+            format!("cargo_iq={}", level)
+                .parse()
+                .expect("Failed to parse level directive"),
+        )
+}
+
+pub fn construct_logger(folder: &str, log_level_filter: EnvFilter) {
     let home = home_dir().unwrap();
 
-    let log_location_base_dir = ternary!(iq, home.join(".iqserver"), home.join(".ossindex"));
-    let full_log_location = log_location_base_dir.join("cargo-pants.combined.log");
+    let log_folder = home.join(folder);
+    std::fs::create_dir_all(&log_folder).expect("Could not create the log folder");
 
-    let file = FileAppender::builder()
-        .encoder(Box::new(JsonEncoder::new()))
-        .build(full_log_location.clone())
-        .unwrap();
+    let log_location = log_folder.join("cargo-pants.combined.log");
 
-    let config = Config::builder()
-        .appender(Appender::builder().build("file", Box::new(file)))
-        .logger(
-            Logger::builder()
-                .appender("file")
-                .additive(true)
-                .build("app::file", log_level_filter),
-        )
-        .build(Root::builder().appender("file").build(log_level_filter))
-        .unwrap();
+    let log_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_location)
+        .expect("Failed to open log file for writing");
 
-    let _handle = log4rs::init_config(config).unwrap();
+    tracing_subscriber::fmt()
+        .with_env_filter(log_level_filter)
+        .json()
+        .with_writer(Mutex::new(log_file))
+        .init();
 
     println!();
-    println!("Log Level set to: {}", log_level_filter);
-    println!("Logging to: {:?}", full_log_location.clone());
+    println!("Logging to: {:?}", log_location.clone());
     println!();
 }

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::Vulnerability;
+use serde::Deserialize;
 use std::fmt;
 
 #[derive(Debug, Default, Deserialize)]

--- a/src/cyclonedx.rs
+++ b/src/cyclonedx.rs
@@ -16,7 +16,6 @@ extern crate packageurl;
 extern crate quick_xml;
 
 use crate::Package;
-use log::trace;
 use packageurl::PackageUrl;
 use quick_xml::events::BytesEnd;
 use quick_xml::events::BytesStart;
@@ -25,6 +24,7 @@ use quick_xml::events::Event;
 use quick_xml::Writer;
 use std::io::Cursor;
 use std::str::FromStr;
+use tracing::trace;
 
 pub struct CycloneDXGenerator();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,20 +13,13 @@
 // limitations under the License.
 #![allow(dead_code)]
 
-extern crate serde;
-extern crate url;
-
-#[macro_use]
-extern crate serde_derive;
-extern crate log;
-extern crate serde_json;
-
-use log::trace;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 use terminal_size::{terminal_size, Height, Width};
+use tracing::trace;
 
 pub mod client;
 pub mod common;
@@ -50,13 +43,13 @@ pub fn calculate_term_width() -> u16 {
     };
 }
 
-#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FilterList {
     pub ignore: Vec<Ignore>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Ignore {
     pub id: String,

--- a/src/package.rs
+++ b/src/package.rs
@@ -15,6 +15,7 @@
 //! Crate metadata as parsed from `Cargo.lock`
 
 use cargo_metadata::Version;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// A Rust package (i.e. crate) as structured in `Cargo.lock`

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -18,7 +18,6 @@ use cargo_metadata::Metadata;
 use cargo_metadata::PackageId;
 use cargo_metadata::Resolve;
 use cargo_metadata::{CargoOpt, MetadataCommand};
-use log::{debug, trace};
 use petgraph::graph::Graph;
 use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
@@ -26,6 +25,7 @@ use petgraph::EdgeDirection;
 use std::collections::HashSet;
 use std::collections::{hash_map::Entry, HashMap, VecDeque};
 use std::ops::Index;
+use tracing::{debug, trace};
 
 #[derive(Clone, Copy)]
 enum Prefix {

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -15,6 +15,7 @@
 use crate::calculate_term_width;
 use console::style;
 use console::StyledObject;
+use serde::Deserialize;
 use std::fmt;
 use std::io::Write;
 


### PR DESCRIPTION
[`log4rs`](https://crates.io/crates/log4rs) has a transitive dependency on `traitobject` that has a vulnerability. There hasn't been a release of `log4rs` in 11 months, so the vulnerability will not likely be addressed in the near future.

[`tracing`](https://crates.io/crates/tracing) is a logging/tracing framework from the Tokio project that is compatible with the output of the [`log`](https://crates.io/crates/log) crate, but provides additional constructs such as spans to make debugging easier compared to correlating lines of output.

This change should be approximately equivalent to the previous solution. An added benefit is that five verbose arguments (`-vvvvv`) cause us to read the `RUST_LOG` environment variable for a tracing directive ([documentation](https://docs.rs/tracing-subscriber/0.3.1/tracing_subscriber/filter/struct.EnvFilter.html#directives)). This directive can be used to target a specific subsection of the program or a dependency, without turning up the logging level for everything (e.g. `RUST_LOG=debug,reqwest=trace` to investigate a network issue).

Additionally, this change includes some code cleanup changes such as removing the old crate macro import syntax for `serde` and removing a ternary macro.

Fixes #59 