### PR TITLE
More error info from IQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,13 @@ Code for `cargo-pants` was influenced by `cargo-audit`, and we acknowledge we st
 You can run your local changes without installing the package via:
 
 ```shell
-cargo run pants
+cargo run --bin cargo-pants pants
 ```
 
 or
 
 ```shell
-cargo run iq --iq-application sandbox-application
+cargo run --bin cargo-iq iq --iq-application sandbox-application
 ```
 
 Use the commands below to build and install the package locally:

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -504,8 +504,8 @@ mod tests {
             .as_bytes();
         let mock = mock("GET", "/api/v2/applications?publicId=iqPublicApplicationId")
             .with_header("CONTENT_TYPE", "application/json")
-            // .with_body(raw_json)
-            .with_body("{}")
+            .with_body(raw_json)
+            //.with_body("{}")
             .create();
         {
             let mock_server = &mockito::server_url();

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -488,20 +488,17 @@ mod tests {
 
     #[test]
     fn test_get_internal_app_id_when_empty() {
-
-        let public_app_id= "iqPublicApplicationId";
+        let public_app_id = "iqPublicApplicationId";
         let mut mock_path = "/api/v2/applications?publicId=".to_owned();
         mock_path.push_str(public_app_id);
 
-        let raw_json: &[u8] =
-            r##""{
+        let raw_json: &str = r#"{
                 "applications": [
                     {
                         "id": "4bb67dcfc86344e3a483832f8c496419"
                     }
                 ]
-            }"##
-            .as_bytes();
+            }"#;
         let mock = mock("GET", "/api/v2/applications?publicId=iqPublicApplicationId")
             .with_header("CONTENT_TYPE", "application/json")
             .with_body(raw_json)
@@ -515,16 +512,13 @@ mod tests {
                 "".parse().unwrap(),
                 "".parse().unwrap(),
                 "iqAppId".parse().unwrap(),
-                0
+                0,
             );
-            let internal_application_id = match client.get_internal_application_id(public_app_id.to_string()) {
-                Ok(internal_application_id) => internal_application_id,
-                Err(_e) => {
-                    ApplicationResponse{applications: vec![]}
-                },
-            };
+            let internal_application_id = client
+                .get_internal_application_id(public_app_id.to_string())
+                .expect("Failed to retrieve application ID");
 
-            assert_eq!(&internal_application_id.applications.len(), &1)
+            assert_eq!(internal_application_id.applications.len(), 1);
         }
         mock.assert();
     }

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -563,9 +563,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "empty application ID: GeneralError(\"could not get internal application id for public application id: "
-    )]
     fn test_audit_with_iq_server_when_applications_empty() {
         let public_app_id = "iqPublicApplicationId".to_string();
         let mock_path = format!("/api/v2/applications?publicId={}", public_app_id);
@@ -588,9 +585,9 @@ mod tests {
                 public_app_id.to_string(),
                 0,
             );
-            let _internal_application_id = client
-                .audit_with_iq_server("".to_string())
-                .expect("empty application ID");
+            let actual_error = client.audit_with_iq_server("".to_string()).err().unwrap();
+            assert!(format!("{}", actual_error).contains(
+                "A general error occurred talking to Nexus IQ Server: could not get internal application id for public application id: "));
         }
         mock.assert();
     }

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -522,7 +522,10 @@ mod tests {
                 .expect("Failed to retrieve application ID");
 
             assert_eq!(internal_application_id.applications.len(), 1);
-            assert_eq!(internal_application_id.applications[0].public_id, public_app_id);
+            assert_eq!(
+                internal_application_id.applications[0].public_id,
+                public_app_id
+            );
         }
         mock.assert();
     }
@@ -560,7 +563,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "empty application ID: GeneralError(\"could not get internal application id for public application id: ")]
+    #[should_panic(
+        expected = "empty application ID: GeneralError(\"could not get internal application id for public application id: "
+    )]
     fn test_audit_with_iq_server_when_applications_empty() {
         let public_app_id = "iqPublicApplicationId".to_string();
         let mock_path = format!("/api/v2/applications?publicId={}", public_app_id);

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -308,7 +308,7 @@ impl IQClient {
         };
 
         if internal_application_id.applications.len() == 0 {
-            return Err(Box::new(GeneralError(format!("could not get internal application id for public application id: {}. perhaps you lack permissions on this application?", app.to_string()).into())));
+            return Err(Box::new(GeneralError(format!("could not get internal application id for public application id: {}. perhaps you ({}) lack permissions on this application?", app.to_string(), &self.user.to_string()).into())));
         }
         let internal_app = &internal_application_id.applications[0].id;
 


### PR DESCRIPTION
Show more information to the user about why calls to IQ might fail, and/or handle empty results from IQ calls more gracefully and try to help the user solve the problem (e.g. missing permissions on the IQ application, etc).

It relates to the following issue #s:
* Fixes #61
