### PR TITLE
fix: Add a feature for vendored openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "cargo_metadata",
  "console",
@@ -670,6 +670,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +687,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ url = "2.2.2"
 [dev-dependencies]
 env_logger = "0.9.0"
 mockito = "0.30.0"
+
+[features]
+vendored-openssl = ["reqwest/native-tls-vendored"]


### PR DESCRIPTION
This helps out when compiling the library with statically linked versions of openssl

This pull request makes the following changes:
* It adds an optional feature for vendored openssl

