### PR TITLE
detect missing IQ license

### DIFF
--- a/.circleci/ci-publish.sh
+++ b/.circleci/ci-publish.sh
@@ -11,7 +11,7 @@ VERSION=$(grep -e '^version' Cargo.toml | cut -d "\"" -f2)
 
 cargo uninstall cargo-bump
 
-cargo publish --token $CARGO_REGISTRY_TOKEN --verbose --allow-dirty
+cargo publish --token "$CARGO_REGISTRY_TOKEN" --verbose --allow-dirty
 
 git commit -am "[skip ci] new development bump to $VERSION"
 

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -380,6 +380,14 @@ impl IQClient {
             .basic_auth(&self.user.to_string(), Some(&self.token.to_string()))
             .send()?;
 
+        let error_message = match res.status() {
+            StatusCode::OK => "",
+            StatusCode::PAYMENT_REQUIRED => "Status 402: Missing or expired IQ Server license?\n",
+            _ => "Received odd response status\n",
+        };
+
+        print!("{}", error_message);
+
         return res.json();
     }
 
@@ -527,6 +535,36 @@ mod tests {
                 internal_application_id.applications[0].public_id,
                 public_app_id
             );
+        }
+        mock.assert();
+    }
+
+    #[test]
+    fn test_get_internal_app_id_missing_license() {
+        let public_app_id = "iqPublicApplicationId".to_string();
+        let mock_path = format!("/api/v2/applications?publicId={}", public_app_id);
+
+        let raw_json: &str = r#"Payment required"#;
+        let mock = mock("GET", mock_path.as_str())
+            .with_header("CONTENT_TYPE", "application/json")
+            .with_body(raw_json)
+            .with_status(402)
+            .create();
+        {
+            let mock_server = &mockito::server_url();
+            let client = IQClient::new(
+                mock_server.parse().unwrap(),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+                public_app_id.to_string(),
+                0,
+            );
+            let result = client
+                .get_internal_application_id(public_app_id.to_string());
+
+            let actual_error = result.unwrap_err();
+            assert_eq!("error decoding response body: expected value at line 1 column 1", actual_error.to_string())
         }
         mock.assert();
     }

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -380,6 +380,7 @@ impl IQClient {
             .basic_auth(&self.user.to_string(), Some(&self.token.to_string()))
             .send()?;
 
+        // NOTE: This doesn't work, because the res.json() call has not yet resolved the status value
         let error_message = match res.status() {
             StatusCode::OK => "",
             StatusCode::PAYMENT_REQUIRED => "Status 402: Missing or expired IQ Server license?\n",

--- a/src/iq.rs
+++ b/src/iq.rs
@@ -561,11 +561,13 @@ mod tests {
                 public_app_id.to_string(),
                 0,
             );
-            let result = client
-                .get_internal_application_id(public_app_id.to_string());
+            let result = client.get_internal_application_id(public_app_id.to_string());
 
             let actual_error = result.unwrap_err();
-            assert_eq!("error decoding response body: expected value at line 1 column 1", actual_error.to_string())
+            assert_eq!(
+                "error decoding response body: expected value at line 1 column 1",
+                actual_error.to_string()
+            )
         }
         mock.assert();
     }


### PR DESCRIPTION
Trying to provide helpful error message when an IQ server license is missing or expired.

Not sure how to intercept the 402 status code with error case/match. Suggestions welcome! 

Should also test behavior with an expired license (would expect it to be the same).