### PR TITLE
Adding the summary section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pants"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "cargo_metadata",
  "console",

--- a/src/bin/pants/main.rs
+++ b/src/bin/pants/main.rs
@@ -25,6 +25,10 @@ use std::io::{stdout, Write};
 use std::path::PathBuf;
 use std::{env, io, process};
 
+use term_table::row::Row;
+use term_table::table_cell::TableCell;
+use term_table::Table;
+
 #[path = "../../common.rs"]
 mod common;
 
@@ -211,6 +215,29 @@ fn write_package_output(
                         .expect("Unable to output Vulnerability details");
                     writeln!(output, "\n")?;
                 }
+            }
+
+            // Creating the overall table for displaying the summary of the scan
+            let mut table = Table::new();
+            table.max_column_width = 40;
+            table.add_row(Row::new(vec![TableCell::new("Summary")]));
+
+            if cfg!(windows) {
+                table.style = term_table::TableStyle::simple();
+            } else {
+                table.style = term_table::TableStyle::rounded();
+            }
+
+            if enable_color {
+            } else {
+                table.add_row(Row::new(vec![
+                    TableCell::new("Audited Dependencies"),
+                    TableCell::new_with_col_span(coordinates.len() as u32, 1),
+                ]));
+                table.add_row(Row::new(vec![
+                    TableCell::new("Vulnerable Dependencies"),
+                    TableCell::new_with_col_span(coordinate.vulnerabilities.len() as u32, 1),
+                ]));
             }
 
             println!("Inverse Dependency graph");

--- a/src/bin/pants/main.rs
+++ b/src/bin/pants/main.rs
@@ -229,6 +229,14 @@ fn write_package_output(
             }
 
             if enable_color {
+                table.add_row(Row::new(vec![
+                    TableCell::new("Na servas de auditoria"),
+                    TableCell::new_with_col_span(coordinates.len() as u32, 1),
+                ]));
+                table.add_row(Row::new(vec![
+                    TableCell::new("Vulnerable Dependencies"),
+                    TableCell::new_with_col_span(coordinate.vulnerabilities.len() as u32, 1),
+                ]));
             } else {
                 table.add_row(Row::new(vec![
                     TableCell::new("Audited Dependencies"),

--- a/src/bin/pants/main.rs
+++ b/src/bin/pants/main.rs
@@ -220,23 +220,6 @@ fn write_package_output(
             println!("Inverse Dependency graph");
             assert!(parser.print_the_graph(coordinate.purl.clone()).is_ok());
             println!();
-
-            // Creating the overall table for displaying the summary of the scan
-            let mut table = Table::new();
-            table.max_column_width = 40;
-            table.add_row(Row::new(vec![TableCell::new("Summary")]));
-
-            table.add_row(Row::new(vec![
-                TableCell::new("Na servas de auditoria"),
-                TableCell::new_with_col_span(coordinates.len() as u32, 1),
-            ]));
-            table.add_row(Row::new(vec![
-                TableCell::new("Vulnerable Dependencies"),
-                TableCell::new_with_col_span(coordinate.vulnerabilities.len() as u32, 1),
-            ]));
-        
-            println!("Karl's summary");
-            println!("{}", table.render());
         }
     }
     Ok(())
@@ -254,6 +237,23 @@ fn get_summary_message(component_count: u32, vulnerability_count: u32) -> String
         "\nAudited Dependencies: {}\nVulnerable Dependencies: {}\n",
         component_count, vulnerability_count
     );
+
+    // Creating the overall table for displaying the summary of the scan
+    let mut table = Table::new();
+    table.max_column_width = 40;
+    table.add_row(Row::new(vec![TableCell::new("Summary")]));
+
+    table.add_row(Row::new(vec![
+        TableCell::new("Na servas de auditoria"),
+        TableCell::new_with_col_span(component_count as u32, 1),
+    ]));
+    table.add_row(Row::new(vec![
+        TableCell::new("Vulnerable Dependencies"),
+        TableCell::new_with_col_span(vulnerability_count as u32, 1),
+    ]));
+
+    println!("Karl's summary");
+    println!("{}", table.render());
     return message;
 }
 

--- a/src/bin/pants/main.rs
+++ b/src/bin/pants/main.rs
@@ -217,6 +217,10 @@ fn write_package_output(
                 }
             }
 
+            println!("Inverse Dependency graph");
+            assert!(parser.print_the_graph(coordinate.purl.clone()).is_ok());
+            println!();
+
             // Creating the overall table for displaying the summary of the scan
             let mut table = Table::new();
             table.max_column_width = 40;
@@ -247,10 +251,6 @@ fn write_package_output(
                     TableCell::new_with_col_span(coordinate.vulnerabilities.len() as u32, 1),
                 ]));
             }
-
-            println!("Inverse Dependency graph");
-            assert!(parser.print_the_graph(coordinate.purl.clone()).is_ok());
-            println!();
         }
     }
     Ok(())

--- a/src/bin/pants/main.rs
+++ b/src/bin/pants/main.rs
@@ -226,31 +226,17 @@ fn write_package_output(
             table.max_column_width = 40;
             table.add_row(Row::new(vec![TableCell::new("Summary")]));
 
-            if cfg!(windows) {
-                table.style = term_table::TableStyle::simple();
-            } else {
-                table.style = term_table::TableStyle::rounded();
-            }
-
-            if enable_color {
-                table.add_row(Row::new(vec![
-                    TableCell::new("Na servas de auditoria"),
-                    TableCell::new_with_col_span(coordinates.len() as u32, 1),
-                ]));
-                table.add_row(Row::new(vec![
-                    TableCell::new("Vulnerable Dependencies"),
-                    TableCell::new_with_col_span(coordinate.vulnerabilities.len() as u32, 1),
-                ]));
-            } else {
-                table.add_row(Row::new(vec![
-                    TableCell::new("Audited Dependencies"),
-                    TableCell::new_with_col_span(coordinates.len() as u32, 1),
-                ]));
-                table.add_row(Row::new(vec![
-                    TableCell::new("Vulnerable Dependencies"),
-                    TableCell::new_with_col_span(coordinate.vulnerabilities.len() as u32, 1),
-                ]));
-            }
+            table.add_row(Row::new(vec![
+                TableCell::new("Na servas de auditoria"),
+                TableCell::new_with_col_span(coordinates.len() as u32, 1),
+            ]));
+            table.add_row(Row::new(vec![
+                TableCell::new("Vulnerable Dependencies"),
+                TableCell::new_with_col_span(coordinate.vulnerabilities.len() as u32, 1),
+            ]));
+        
+            println!("Karl's summary");
+            println!("{}", table.render());
         }
     }
     Ok(())

--- a/src/bin/pants/main.rs
+++ b/src/bin/pants/main.rs
@@ -241,18 +241,21 @@ fn get_summary_message(component_count: u32, vulnerability_count: u32) -> String
     // Creating the overall table for displaying the summary of the scan
     let mut table = Table::new();
     table.max_column_width = 40;
+    if cfg!(windows) {
+        table.style = term_table::TableStyle::simple();
+    } else {
+        table.style = term_table::TableStyle::rounded();
+    }
     table.add_row(Row::new(vec![TableCell::new("Summary")]));
-
     table.add_row(Row::new(vec![
-        TableCell::new("Na servas de auditoria"),
+        TableCell::new("Audited Dependencies"),
         TableCell::new_with_col_span(component_count as u32, 1),
     ]));
     table.add_row(Row::new(vec![
         TableCell::new("Vulnerable Dependencies"),
-        TableCell::new_with_col_span(vulnerability_count as u32, 1),
+        TableCell::new_with_col_span(style(vulnerability_count as u32).red(), 1),
     ]));
 
-    println!("Karl's summary");
     println!("{}", table.render());
     return message;
 }


### PR DESCRIPTION
Hi!

I have just seen that the summary section for the project was still not implemented, so I have done the table styling

This pull request makes the following changes:
* Adding the summary table at the end 
* Using the already build get_summary_message function
* Formatting the table and making the output red
* No changes to the user behaviour

It relates to the following issue #s:
* Fixes https://github.com/sonatype-nexus-community/cargo-pants/issues/14
