### PR TITLE
Add OSS Index HTTP Basic authentication support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,7 @@ dependencies = [
 name = "cargo-pants"
 version = "0.4.39"
 dependencies = [
+ "base64 0.21.7",
  "cargo_metadata",
  "console",
  "dirs",
@@ -892,7 +899,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = "1.0.30"
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 url = "2.2.2"
+base64 = "0.21"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Don't you check your pants for holes? Similarly, we think you should check your 
 $ cargo install cargo-pants
 ```
 
-Set an environment variable `OSS_INDEX_API_KEY` to auth requests with your key.
+Set environment variables `OSS_INDEX_USERNAME` and `OSS_INDEX_API_KEY` (or pass `--ossi-username` / `--ossi-api-key`) so requests authenticate against OSS Index.
 
 Once you have installed `cargo-pants`, you can run it like so:
 
@@ -70,6 +70,7 @@ FLAGS:
 
 OPTIONS:
         --ignore-file <ignore-file>           The path to your .pants-ignore file [default: .pants-ignore]
+        --ossi-username <oss-index-username>  OSS Index Username [env: OSS_INDEX_USERNAME]
         --ossi-api-key <oss-index-api-key>    OSS Index API Key [env: OSS_INDEX_API_KEY]
     -s, --pants_style <pants-style>           Your pants style
         --tomlfile <toml-file>                The path to your Cargo.toml file [default: Cargo.toml]

--- a/src/bin/pants/cli.rs
+++ b/src/bin/pants/cli.rs
@@ -55,6 +55,10 @@ pub enum Opt {
         #[structopt(short = "s", long = "pants_style")]
         pants_style: Option<String>,
 
+        /// OSS Index username
+        #[structopt(long = "ossi-username", env, hide_env_values = true)]
+        oss_index_username: Option<String>,
+
         /// OSS Index API Key
         #[structopt(long = "ossi-api-key", env, hide_env_values = true)]
         oss_index_api_key: Option<String>,


### PR DESCRIPTION
• Sonatype OSS Index now requires HTTP Basic authentication (username + API token). Without adding the auth header, cargo pants keeps returning “Audited Dependencies: 0” because every request is rejected.

What’s in this PR

  - CLI accepts --ossi-username/OSS_INDEX_USERNAME alongside the existing API key.
  - OSSIndexClient builds a Basic auth header and continues to append the legacy query parameter when the key is present.
  - Added the base64 dependency to encode credentials and updated tests to assert the header.
  - Docs/help text updated to describe the new username requirement.

Testing

  - Verified locally: cargo run --bin cargo-pants -- pants --ossi-username … --ossi-api-key … now returns the expected dependency count, and using -vvvv shows successful OSS Index responses.

I didn’t see an existing ticket covering this.