### PR TITLE
fix: warning: unexpected `cfg` condition value: `chrono`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ mockito = "0.30.0"
 
 [features]
 vendored-openssl = ["reqwest/native-tls-vendored"]
+chrono = []


### PR DESCRIPTION
Fix compiler warning: warning: unexpected `cfg` condition value: `chrono`
