### PR TITLE
Add configurable OSS Index URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ $ cargo install cargo-pants
 
 Set an environment variable `OSS_INDEX_API_KEY` to auth requests with your key.
 
+You can optionally set an environment variable `OSS_INDEX_URL` to override the default OSS Index server URL (defaults to `https://ossindex.sonatype.org/api/v3/`).
+
 Once you have installed `cargo-pants`, you can run it like so:
 
 ``` shell
@@ -71,6 +73,7 @@ FLAGS:
 OPTIONS:
         --ignore-file <ignore-file>           The path to your .pants-ignore file [default: .pants-ignore]
         --ossi-api-key <oss-index-api-key>    OSS Index API Key [env: OSS_INDEX_API_KEY]
+        --ossi-url <oss-index-url>            OSS Index URL [env: OSS_INDEX_URL]
     -s, --pants_style <pants-style>           Your pants style
         --tomlfile <toml-file>                The path to your Cargo.toml file [default: Cargo.toml]
 ```
@@ -100,6 +103,23 @@ $ cargo pants --no-color
 This disables any coloring of the output.
 
 If vulnerabilities are found, `cargo-pants` exits with status code 3, and prints the Bill Of Materials/Found Vulnerabilities. If there are no issues, it will exit with status code 0.
+
+### Using a Custom OSS Index Server
+
+You can configure `cargo-pants` to use a custom OSS Index server URL in two ways:
+
+1. Via environment variable:
+``` shell
+$ export OSS_INDEX_URL=https://custom.ossindex.org/api/v3/
+$ cargo pants
+```
+
+2. Via command line flag:
+``` shell
+$ cargo pants --ossi-url https://custom.ossindex.org/api/v3/
+```
+
+This is useful for enterprise environments where you may be running your own instance of OSS Index or need to point to a different server for testing purposes.
 
 ### Excluding Vulnerabilities
 

--- a/src/bin/pants/cli.rs
+++ b/src/bin/pants/cli.rs
@@ -59,6 +59,10 @@ pub enum Opt {
         #[structopt(long = "ossi-api-key", env, hide_env_values = true)]
         oss_index_api_key: Option<String>,
 
+        /// OSS Index URL
+        #[structopt(long = "ossi-url", env = "OSS_INDEX_URL")]
+        oss_index_url: Option<String>,
+
         /// The path to your .pants-ignore file
         #[structopt(long = "ignore-file", default_value = ".pants-ignore")]
         ignore_file: PathBuf,

--- a/src/bin/pants/main.rs
+++ b/src/bin/pants/main.rs
@@ -46,6 +46,7 @@ fn main() {
             no_color,
             pants_style,
             oss_index_api_key,
+            oss_index_url,
             ignore_file,
         } => {
             common::construct_logger(".ossindex", log_level);
@@ -59,6 +60,7 @@ fn main() {
             audit(
                 toml_file.to_string_lossy().to_string(),
                 oss_index_api_key,
+                oss_index_url,
                 loud,
                 !no_color,
                 include_dev_dependencies,
@@ -71,6 +73,7 @@ fn main() {
 fn audit(
     toml_file_path: String,
     oss_index_api_key: Option<String>,
+    oss_index_url: Option<String>,
     verbose_output: bool,
     enable_color: bool,
     include_dev: bool,
@@ -93,7 +96,13 @@ fn audit(
         }
     };
 
-    let client = OSSIndexClient::new(api_key);
+    let client = match oss_index_url {
+        Some(url) => {
+            info!("Using custom OSS Index URL: {}", url);
+            OSSIndexClient::new_with_url(api_key, url)
+        }
+        None => OSSIndexClient::new(api_key),
+    };
     let mut coordinates: Vec<Coordinate> = Vec::new();
     for chunk in packages.chunks(128) {
         coordinates.append(&mut client.post_coordinates(chunk.to_vec()));

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,6 +46,14 @@ impl OSSIndexClient {
         OSSIndexClient { url_maker }
     }
 
+    pub fn new_with_url(key: String, url: String) -> OSSIndexClient {
+        debug!("Value for ossindex_api_base: {}", url);
+
+        let url_maker = UrlMaker::new(url, key);
+
+        OSSIndexClient { url_maker }
+    }
+
     fn construct_headers(&self) -> HeaderMap {
         const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
@@ -126,6 +134,15 @@ mod tests {
         let key = String::from("ALL_YOUR_KEY");
         let client = OSSIndexClient::new(key);
         assert_eq!(client.url_maker.api_key, "ALL_YOUR_KEY");
+    }
+
+    #[test]
+    fn new_ossindexclient_with_custom_url() {
+        let key = String::from("ALL_YOUR_KEY");
+        let custom_url = String::from("https://custom.ossindex.org/api/v3/");
+        let client = OSSIndexClient::new_with_url(key, custom_url.clone());
+        assert_eq!(client.url_maker.api_key, "ALL_YOUR_KEY");
+        assert_eq!(client.url_maker.api_base, custom_url);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds the ability to configure a custom OSS Index server URL, enabling cargo-pants to work with enterprise or custom OSS Index deployments.

Previously, the OSS Index URL was hardcoded to `https://ossindex.sonatype.org/api/v3/`. This enhancement allows users to override it via:
- Command line flag: `--ossi-url`
- Environment variable: `OSS_INDEX_URL`

## Changes

- ✅ Added `--ossi-url` CLI parameter in `src/bin/pants/cli.rs`
- ✅ Implemented `OSSIndexClient::new_with_url()` method in `src/client.rs`
- ✅ Updated `main.rs` to use custom URL when provided
- ✅ Added unit test `new_ossindexclient_with_custom_url()` for custom URL functionality
- ✅ Updated README with usage examples and documentation

## Test Results

All tests pass (19 tests total):
- ✅ Existing tests: All passing (no regressions)
- ✅ New test: Custom URL functionality verified
- ✅ Build: Successful with no new warnings

## Usage Examples

Via environment variable:
```bash
export OSS_INDEX_URL=https://custom.ossindex.org/api/v3/
cargo pants
```

Via command line flag:
```bash
cargo pants --ossi-url https://custom.ossindex.org/api/v3/
```

## Backward Compatibility

✅ Fully backward compatible - when no custom URL is provided, defaults to production OSS Index URL

## Related

This follows the same pattern implemented in other Sonatype OSS Index clients (e.g., auditjs) for consistency across the ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)