### PR TITLE
fix: failing test: handle_iq_purl_suffix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   circleci-rust-docker:
     docker:
-      - image: cimg/rust:1.84
+      - image: cimg/rust:1.87
 
 jobs:
   release:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: rust:1.84
+    container: rust:1.87
     env:
       SLACK_ACCESS_TOKEN:
       SLACK_DEFAULT_CHANNEL:
@@ -64,7 +64,7 @@ jobs:
     if: ${{ false }}  # disable for now
 #    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    container: rust:1.84
+    container: rust:1.87
     needs:
     - build
     env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,6 @@ dependencies = [
  "structopt",
  "term-table",
  "terminal_size",
- "textwrap 0.14.2",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -161,7 +160,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
@@ -1035,12 +1034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
-name = "smawk"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
-
-[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,17 +1134,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-dependencies = [
- "smawk",
- "unicode-linebreak",
  "unicode-width",
 ]
 
@@ -1333,15 +1315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
-]
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
-dependencies = [
- "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/sonatype-nexus-community/cargo-pants"
 description = "cargo-pants is a cargo subcommand application that provides a bill of materials and a list of which dependencies have a vulnerability, powered by Sonatype OSSIndex"
 license = "Apache-2.0"
-rust-version = "1.69"
+rust-version = "1.87"
 
 [[bin]]
 name = "cargo-pants"
@@ -33,7 +33,6 @@ serde_json = "1.0.69"
 structopt = "0.3.25"
 term-table = "1.3.2"
 terminal_size = "0.1.17"
-textwrap = "0.14.2"
 thiserror = "1.0.30"
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }

--- a/src/bin/iq/main.rs
+++ b/src/bin/iq/main.rs
@@ -337,9 +337,7 @@ mod tests {
     #[test]
     fn handle_iq_purl_suffix() {
         // find pure purl to use for test
-        //let mut parser = ParseCargoToml::default(); // @todo Why does this not work under debug mode?
-        let mut parser =
-            ParseCargoToml::new(crate::common::CARGO_DEFAULT_TOMLFILE.to_string(), false); // @todo Why does this not work under debug mode?
+        let mut parser = ParseCargoToml::default(); // @todo Why does this not work under debug mode?
         let packages = match parser.get_packages() {
             Ok(packages) => packages,
             Err(e) => {

--- a/src/bin/iq/main.rs
+++ b/src/bin/iq/main.rs
@@ -338,7 +338,8 @@ mod tests {
     fn handle_iq_purl_suffix() {
         // find pure purl to use for test
         //let mut parser = ParseCargoToml::default(); // @todo Why does this not work under debug mode?
-        let mut parser = ParseCargoToml::new(crate::common::CARGO_DEFAULT_TOMLFILE.to_string(), false); // @todo Why does this not work under debug mode?
+        let mut parser =
+            ParseCargoToml::new(crate::common::CARGO_DEFAULT_TOMLFILE.to_string(), false); // @todo Why does this not work under debug mode?
         let packages = match parser.get_packages() {
             Ok(packages) => packages,
             Err(e) => {

--- a/src/bin/iq/main.rs
+++ b/src/bin/iq/main.rs
@@ -337,7 +337,8 @@ mod tests {
     #[test]
     fn handle_iq_purl_suffix() {
         // find pure purl to use for test
-        let mut parser = ParseCargoToml::default(); // @todo Why does this not work under debug mode?
+        //let mut parser = ParseCargoToml::default(); // @todo Why does this not work under debug mode?
+        let mut parser = ParseCargoToml::new(crate::common::CARGO_DEFAULT_TOMLFILE.to_string(), false); // @todo Why does this not work under debug mode?
         let packages = match parser.get_packages() {
             Ok(packages) => packages,
             Err(e) => {


### PR DESCRIPTION
Attempt to fix: failing test: handle_iq_purl_suffix, not sure why it started failing though.

Looks like a newer version of rust was needed to get things happy.
